### PR TITLE
Add endpoint to get item tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ compatibility)
 - `GET` all upstream relationships for an item by item ID
 - `GET` all children of an item
 - `GET` all synced items
+- `GET` all tags of an item
 - `GET` synced item sync status
 - `GET` Locked state of an item
 - `DELETE` an Item by ID

--- a/py_jama_rest_client/client.py
+++ b/py_jama_rest_client/client.py
@@ -205,6 +205,21 @@ class JamaClient:
         response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
         return self.__handle_response_status(response)
 
+    def get_item_tags(self, item_id):
+        """
+        Return all tags for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: a dictionary object representing the item's tags
+
+        """
+        resource_path = 'items/' + str(item_id) + '/tags'
+        response = self.__core.get(resource_path)
+        JamaClient.__handle_response_status(response)
+        return response.json()['data']
+
     def get_attachment(self, attachment_id):
         """
         This method will return a singular attachment of a specified attachment id

--- a/py_jama_rest_client/client.py
+++ b/py_jama_rest_client/client.py
@@ -216,9 +216,8 @@ class JamaClient:
 
         """
         resource_path = 'items/' + str(item_id) + '/tags'
-        response = self.__core.get(resource_path)
-        JamaClient.__handle_response_status(response)
-        return response.json()['data']
+        item_tags = self.__get_all(resource_path)
+        return item_tags
 
     def get_attachment(self, attachment_id):
         """

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.14.0',  # Required
+    version='1.15.0',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
This pull request adds a new client method named `get_item_tags` to return all tags for the specified item ID. 

I tried updating the documentation and adding tests as described in `CONTRIBUTING.md`, however it appears that the `pdoc` CLI has changed in a backwards-incompatible way since the guide was written. In addition, the tests appear to be functional tests and I don't have access to the Jama project used by those tests.

I suspect I won't be able to publish to PyPI either, so I'll leave that step to the maintainers. I did update the `setup.py` version already for your convenience.