### PR TITLE
Add support for get_filter_results_count and get_item_links

### DIFF
--- a/docs/py_jama_rest_client/client.html
+++ b/docs/py_jama_rest_client/client.html
@@ -3,29 +3,33 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.5.3" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>py_jama_rest_client.client API documentation</title>
 <meta name="description" content="" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.name small{font-weight:normal}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase;cursor:pointer}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
 <article id="content">
 <header>
-<h1 class="title"><code>py_jama_rest_client.client</code> module</h1>
+<h1 class="title">Module <code>py_jama_rest_client.client</code></h1>
 </header>
 <section id="section-intro">
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">import json
 import logging
 
-from .core import Core
+from .core import Core, CoreException
 
 # This is the py_jama_rest_client logger.
 py_jama_rest_client_logger = logging.getLogger(&#39;py_jama_rest_client&#39;)
@@ -75,8 +79,12 @@ class JamaClient:
 
     __allowed_results_per_page = 20  # Default is 20, Max is 50. if set to greater than 50, only 50 will items return.
 
-    def __init__(self, host_domain, credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;), api_version=&#39;/rest/v1/&#39;,
-                 oauth=False, verify=True):
+    def __init__(self, host_domain,
+                 credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;),
+                 api_version=&#39;/rest/v1/&#39;,
+                 oauth=False,
+                 verify=True,
+                 allowed_results_per_page=20):
         &#34;&#34;&#34;Jama Client initializer
         :rtype: JamaClient
         :param host_domain: String The domain associated with the Jama Connect host
@@ -84,7 +92,12 @@ class JamaClient:
         :param api_version: valid args are &#39;/rest/[v1|latest|labs]/&#39;
         :param verify: Defaults to True, Setting this to False will skip SSL Certificate verification&#34;&#34;&#34;
         self.__credentials = credentials
-        self.__core = Core(host_domain, credentials, api_version=api_version, oauth=oauth, verify=verify)
+        self.__allowed_results_per_page = allowed_results_per_page
+        try:
+            self.__core = Core(host_domain, credentials, api_version=api_version, oauth=oauth, verify=verify)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # Log client creation
         py_jama_rest_client_logger.info(&#39;Created a new JamaClient instance. Domain: {} &#39;
@@ -97,21 +110,26 @@ class JamaClient:
         Returns: an array of available endpoints for this API
 
         &#34;&#34;&#34;
-        response = self.__core.get(&#39;&#39;)
+        try:
+            response = self.__core.get(&#39;&#39;)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_baselines(self, project_id):
+    def get_baselines(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of Baseline objects
         Args:
             project_id:  the Id of the project to fetch baselines for
+            allowed_results_per_page: number of results per page
 
         Returns: a list of Baseline objects
         &#34;&#34;&#34;
         resource_path = &#39;baselines&#39;
         params = {&#39;project&#39;: project_id}
-        baseline_data = self.__get_all(resource_path, params=params)
+        baseline_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return baseline_data
 
     def get_baseline(self, baseline_id):
@@ -124,37 +142,42 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;baselines/&#39; + str(baseline_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_baselines_versioneditems(self, baseline_id):
+    def get_baselines_versioneditems(self, baseline_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all baseline items in a baseline with the specified ID
         Args:
             baseline_id:  The id of the baseline to fetch items for.
-
+            allowed_results_per_page: Number of results per page
         Returns: A list of versioned items belonging to the baseline
         &#34;&#34;&#34;
         resource_path = &#39;baselines/&#39; + str(baseline_id) + &#39;/versioneditems&#39;
-        baseline_items = self.__get_all(resource_path)
+        baseline_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return baseline_items
 
-    def get_projects(self):
+    def get_projects(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;This method will return all projects as JSON object
         :return: JSON Array of Item Objects.
         &#34;&#34;&#34;
         resource_path = &#39;projects&#39;
-        project_data = self.__get_all(resource_path)
+        project_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return project_data
 
-    def get_filter_results(self, filter_id, project_id=None):
+    def get_filter_results(self, filter_id, project_id=None, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all results items for the filter with the specified ID
 
         Args:
             filter_id: The ID of the filter to fetch the results for.
             project_id: Use this only for filters that run on any project, where projectScope is CURRENT
+            allowed_results_per_page: Number of results per page
 
         Returns:
             A List of items that match the filter.
@@ -164,21 +187,22 @@ class JamaClient:
         params = None
         if project_id is not None:
             params = {&#39;project&#39;: str(project_id)}
-        filter_results = self.__get_all(resource_path, params=params)
+        filter_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return filter_results
 
-    def get_items(self, project_id):
+    def get_items(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all items in the specified project.
         Args:
             project_id: the project ID
+            allowed_results_per_page: number of results per page
 
         Returns: a Json array of item objects
 
         &#34;&#34;&#34;
         resource_path = &#39;items&#39;
         params = {&#39;project&#39;: project_id}
-        item_data = self.__get_all(resource_path, params=params)
+        item_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return item_data
 
     def get_item(self, item_id):
@@ -191,7 +215,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -206,7 +234,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -226,8 +258,27 @@ class JamaClient:
         }
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
+
+    def get_item_tags(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+        &#34;&#34;&#34;
+        Return all tags for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            allowed_results_per_page: number of results
+
+        Returns: a dictionary object representing the item&#39;s tags
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
+        item_tags = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+        return item_tags
 
     def get_attachment(self, attachment_id):
         &#34;&#34;&#34;
@@ -239,28 +290,69 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;attachments/&#39; + str(attachment_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_abstract_items_from_doc_key(self, doc_key_list):
+    def get_abstract_items_from_doc_key(self, doc_key_list, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34; DEPRECATED INSTEAD USE get_abstract_items below.
         This method will take in a list of document keys and return an array of JSON Objects associated with the
         document keys.&#34;&#34;&#34;
         resource_path = &#39;abstractitems&#39;
         params = {&#39;documentKey&#39;: doc_key_list}
-        abstract_items = self.__get_all(resource_path, params=params)
+        abstract_items = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return abstract_items
 
-    def get_relationship_types(self):
+    def get_relationship_rule_sets(self):
+        &#34;&#34;&#34;
+        This method will return all relationship rule sets across all projects of the Jama Connect instance.
+
+        Returns: An array of dictionary objects representing a rule set and its associated rules
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39;
+        rule_sets = self.__get_all(resource_path)
+        return rule_sets
+
+    def get_relationship_rule_set(self, id):
+        &#34;&#34;&#34;
+        This method will return the relationship rule sets by id.
+
+        Returns: A dictionary object representing a rule set and its associated rules
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39; + str(id)
+        response = self.__core.get(resource_path)
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_relationship_rule_set_projects(self, id):
+        &#34;&#34;&#34;
+        This method will return the projects that have a given relationship rule set defined.
+
+        Returns: An array of the dictionary objects representing the projects with a given rule set assigned
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39; + str(id) + &#39;/projects&#39;
+        projects = self.__get_all(resource_path)
+        return projects
+
+    def get_relationship_types(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all relationship types of the across all projects of the Jama Connect instance.
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: An array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;relationshiptypes/&#39;
-        item_types = self.__get_all(resource_path)
+        item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return item_types
 
     def get_relationship_type(self, relationship_type_id):
@@ -274,19 +366,26 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;relationshiptypes/&#39; + str(relationship_type_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_item_types(self):
+    def get_item_types(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all item types of the across all projects of the Jama Connect instance.
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: An array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;itemtypes/&#39;
-        item_types = self.__get_all(resource_path)
+        item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return item_types
 
     def get_item_type(self, item_type_id):
@@ -300,23 +399,28 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;itemtypes/&#39; + str(item_type_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_items_synceditems(self, item_id):
+    def get_items_synceditems(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all synchronized items for the item with the specified ID
 
         Args:
             item_id: The API id of the item being
+            allowed_results_per_page: Number of results per page
 
         Returns: A list of JSON Objects representing the items that are in the same synchronization group as the
         specified item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems&#39;
-        synced_items = self.__get_all(resource_path)
+        synced_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return synced_items
 
     def get_items_synceditems_status(self, item_id, synced_item_id):
@@ -331,19 +435,121 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems/&#39; + str(synced_item_id) + &#39;/syncstatus&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_item_versions(self, item_id):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path)
+        return versions
+
+    def get_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_item_versions(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            allowed_results_per_page: number of results per page
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+        return versions
+
+    def get_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
         response = self.__core.get(resource_path)
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_pick_lists(self):
+    def get_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        response = self.__core.get(resource_path)
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_pick_lists(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the pick lists
+
+        Args:
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39;
-        pick_lists = self.__get_all(resource_path)
+        pick_lists = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return pick_lists
 
     def get_pick_list(self, pick_list_id):
@@ -357,21 +563,26 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39; + str(pick_list_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_pick_list_options(self, pick_list_id):
+    def get_pick_list_options(self, pick_list_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Gets all all the picklist options for a single picklist
         Args:
             pick_list_id: the api id of the picklist to fetch options for.
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the picklist options.
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39; + str(pick_list_id) + &#39;/options&#39;
-        pick_list_options = self.__get_all(resource_path)
+        pick_list_options = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return pick_list_options
 
     def get_pick_list_option(self, pick_list_option_id):
@@ -384,23 +595,29 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;picklistoptions/&#39; + str(pick_list_option_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_relationships(self, project_id):
+    def get_relationships(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all relationships of a specified project
 
         Args:
             project_id: the api project id of a project
+            allowed_results_per_page: number of results per page
 
         Returns: a list of dictionary objects that represents a relationships
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships&#39;
         params = {&#39;project&#39;: project_id}
-        relationship_data = self.__get_all(resource_path, params=params)
+        relationship_data = self.__get_all(resource_path, params=params,
+                                           allowed_results_per_page=allowed_results_per_page)
         return relationship_data
 
     def get_relationship(self, relationship_id):
@@ -414,7 +631,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships/&#39; + str(relationship_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -481,51 +702,124 @@ class JamaClient:
         abstract_items = self.__get_all(resource_path, params=params)
         return abstract_items
 
-    def get_item_children(self, item_id):
+    def get_abstract_item(self, item_id):
+        &#34;&#34;&#34;
+        This method will return an item, test plan, test cycle, test run, or attachment with the specified ID
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: a dictonary object representing the abstract item
+
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_abstract_item_versions(self, item_id):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path)
+        return versions
+
+    def get_abtract_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_abstract_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+
+    def get_item_children(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return list of the child items of the item passed to the function.
         Args:
             item_id: (int) The id of the item for which children items should be fetched
+            allowed_results_per_page: Number of results per page
 
         Returns: a List of Objects that represent the children of the item passed in.
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/children&#39;
-        child_items = self.__get_all(resource_path)
+        child_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return child_items
 
-    def get_testruns(self, test_cycle_id):
+    def get_testruns(self, test_cycle_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;This method will return all test runs associated with the specified test cycle.  Test runs will be returned
         as a list of json objects.&#34;&#34;&#34;
         resource_path = &#39;testcycles/&#39; + str(test_cycle_id) + &#39;/testruns&#39;
-        testrun_data = self.__get_all(resource_path)
+        testrun_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return testrun_data
 
-    def get_items_upstream_relationships(self, item_id):
+    def get_items_upstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the upstream relationships for the item with the specified ID.
         Args:
             item_id: the api id of the item
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the upstream relationships for the item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelationships&#39;
-        return self.__get_all(resource_path)
+        return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
 
-    def get_items_downstream_related(self, item_id):
+    def get_items_downstream_related(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the downstream related items for the item with the specified ID.
 
         Args:
             item_id: the api id of the item to fetch downstream items for
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the downstream related items for the specified item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelated&#39;
-        return self.__get_all(resource_path)
+        return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
 
-    def get_items_downstream_relationships(self, item_id):
+    def get_items_downstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the downstream relationships for the item with the specified ID.
 
@@ -536,28 +830,57 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelationships&#39;
+        return self.__get_all(resource_path, allowed_results_per_page=allowed_results_per_page)
+
+    def get_items_upstream_related(self, item_id):
+        &#34;&#34;&#34;
+        Returns a list of all the upstream related items for the item with the specified ID.
+
+        Args:
+            item_id: the api id of the item to fetch upstream items for
+
+        Returns: an array of dictionary objects that represent the upstream related items for the specified item.
+
+         &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelated&#39;
         return self.__get_all(resource_path)
 
-    def get_tags(self, project):
+    def get_item_workflow_transitions(self, item_id):
+        &#34;&#34;&#34;
+        Get all valid workflow transitions that can be made with the specified id
+
+        Args:
+            item_id: the api id of the item
+            allowed_results_per_page: number of results per page
+
+        Returns: an array of dictionary objects that represent the workflow transitions for the item.
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/workflowtransitionoptions&#39;
+        return self.__get_all(resource_path)
+
+    def get_tags(self, project, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all tags for the project with the specified id
         Args:
             project: The API ID of the project to fetch tags for.
+            allowed_results_per_page: Number of results per page
 
         Returns: A Json Array that contains all the tag data for the specified project.
 
         &#34;&#34;&#34;
         resource_path = &#39;tags&#39;
         params = {&#39;project&#39;: project}
-        tag_data = self.__get_all(resource_path, params=params)
+        tag_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return tag_data
 
-    def get_tagged_items(self, tag_id):
+    def get_tagged_items(self, tag_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all items tagged with the specified ID
 
         Args:
             tag_id: The ID of the tag to fetch the results for.
+            allowed_results_per_page: Number of results per page
 
         Returns:
             A List of items that match the tag.
@@ -565,18 +888,57 @@ class JamaClient:
         &#34;&#34;&#34;
         resource_path = &#39;tags/&#39; + str(tag_id) + &#39;/items&#39;
         params = None
-        tag_results = self.__get_all(resource_path, params=params)
+        tag_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return tag_results
 
-    def get_users(self):
+    def get_item_links(self, item_id):
+        &#34;&#34;&#34;
+        This method will return all links in the specified item.
+        Args:
+            item_id: the item ID
+
+        Returns: a Json object with the links present in the item specified
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/links&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_filter_results_count(self, filter_id):
+        &#34;&#34;&#34;
+        This method will return count of items found through the specified filter.
+        Args:
+            filter_id: the filter ID
+
+        Returns: a count of the items matched with the filter
+
+        &#34;&#34;&#34;
+        resource_path = &#39;filters/&#39; + str(filter_id) + &#39;/count&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_users(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Gets a list of all active users visible to the current user
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: JSON array
 
         &#34;&#34;&#34;
         resource_path = &#39;users/&#39;
-        users = self.__get_all(resource_path)
+        users = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return users
 
     def get_user(self, user_id):
@@ -590,7 +952,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;users/&#39; + str(user_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return response.json()[&#39;data&#39;]
 
     def get_current_user(self):
@@ -601,7 +967,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;users/current&#39;
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return response.json()[&#39;data&#39;]
 
     def get_test_cycle(self, test_cycle_id):
@@ -615,7 +985,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;testcycles/&#39; + str(test_cycle_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -629,7 +1003,11 @@ class JamaClient:
         Returns: The success status code.
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id)
-        response = self.__core.delete(resource_path)
+        try:
+            response = self.__core.delete(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -644,7 +1022,11 @@ class JamaClient:
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships/&#39; + str(relationship_id)
-        response = self.__core.delete(resource_path)
+        try:
+            response = self.__core.delete(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -672,7 +1054,11 @@ class JamaClient:
         data = json.dumps(patches)
 
         # Make the API Call
-        response = self.__core.patch(resource_path, data=data, headers=headers)
+        try:
+            response = self.__core.patch(resource_path, data=data, headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # validate response
         JamaClient.__handle_response_status(response)
@@ -711,7 +1097,11 @@ class JamaClient:
         }
         resource_path = &#39;users/&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -730,7 +1120,11 @@ class JamaClient:
             &#39;project&#39;: project
         }
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -770,7 +1164,11 @@ class JamaClient:
         }
 
         # Make the API Call
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # Validate response
         JamaClient.__handle_response_status(response)
@@ -804,7 +1202,11 @@ class JamaClient:
             params[&#39;setGlobalIdManually&#39;] = True
 
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -823,7 +1225,11 @@ class JamaClient:
         }
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -843,7 +1249,11 @@ class JamaClient:
 
         resource_path = &#39;items/&#39; + str(pool_item) + &#39;/synceditems&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -866,7 +1276,11 @@ class JamaClient:
             body[&#39;relationshipType&#39;] = relationship_type
         resource_path = &#39;relationships/&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -880,7 +1294,11 @@ class JamaClient:
         body = {&#34;attachment&#34;: attachment_id}
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/attachments&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -901,7 +1319,11 @@ class JamaClient:
 
         resource_path = &#39;projects/&#39; + str(project_id) + &#39;/attachments&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -927,7 +1349,11 @@ class JamaClient:
         }
         resource_path = &#39;items/&#39; + str(item_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
     def put_attachments_file(self, attachment_id, file_path):
@@ -940,8 +1366,11 @@ class JamaClient:
         resource_path = &#39;attachments/&#39; + str(attachment_id) + &#39;/file&#39;
         with open(file_path, &#39;rb&#39;) as f:
             files = {&#39;file&#39;: f}
-            response = self.__core.put(resource_path, files=files)
-
+            try:
+                response = self.__core.put(resource_path, files=files)
+            except CoreException as err:
+                py_jama_rest_client_logger.error(err)
+                raise APIException(str(err))
         self.__handle_response_status(response)
         return response.status_code
 
@@ -976,7 +1405,12 @@ class JamaClient:
         }
         resource_path = &#39;users/&#39; + str(user_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+            raise APIException
         return self.__handle_response_status(response)
 
     def put_user_active(self, user_id, is_active):
@@ -994,54 +1428,68 @@ class JamaClient:
         }
         resource_path = &#39;users/&#39; + str(user_id) + &#39;/active&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
     def put_test_run(self, test_run_id, data=None):
         &#34;&#34;&#34; This method will post a test run to Jama through the API&#34;&#34;&#34;
         resource_path = &#39;testruns/&#39; + str(test_run_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=data, headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=data, headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
-    def __get_all(self, resource, params=None, **kwargs):
+    def __get_all(self, resource, params=None, allowed_results_per_page=__allowed_results_per_page, **kwargs):
         &#34;&#34;&#34;This method will get all of the resources specified by the resource parameter, if an id or some other
         parameter is required for the resource, include it in the params parameter.
         Returns a single JSON array with all of the retrieved items.&#34;&#34;&#34;
 
+        if allowed_results_per_page &lt; 1 or allowed_results_per_page &gt; 50:
+            raise ValueError(&#34;Allowed results per page must be between 1 and 50&#34;)
+
         start_index = 0
-        result_count = -1
         allowed_results_per_page = 20
+        total_results = float(&#34;inf&#34;)
 
         data = []
 
-        while result_count != 0:
+        while len(data) &lt; total_results:
             page_response = self.__get_page(resource, start_index, params=params, **kwargs)
             page_json = page_response.json()
 
             page_info = page_json[&#39;meta&#39;][&#39;pageInfo&#39;]
             start_index = page_info[&#39;startIndex&#39;] + allowed_results_per_page
-            result_count = page_info[&#39;resultCount&#39;]
-
+            total_results = page_info.get(&#39;totalResults&#39;)
             page_data = page_json.get(&#39;data&#39;)
             data.extend(page_data)
 
         return data
 
-    def __get_page(self, resource, start_at, params=None, **kwargs):
+    def __get_page(self, resource, start_at, params=None,  allowed_results_per_page=__allowed_results_per_page,  **kwargs):
         &#34;&#34;&#34;This method will return one page of results from the specified resource type.
         Pass any needed parameters along
         The response object will be returned&#34;&#34;&#34;
         parameters = {
             &#39;startAt&#39;: start_at,
-            &#39;maxResults&#39;: self.__allowed_results_per_page
+            &#39;maxResults&#39;: allowed_results_per_page
         }
 
         if params is not None:
             for k, v in params.items():
                 parameters[k] = v
 
-        response = self.__core.get(resource, params=parameters, **kwargs)
+        try:
+            response = self.__core.get(resource, params=parameters, **kwargs)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response
 
@@ -1111,7 +1559,14 @@ class JamaClient:
         py_jama_rest_client_logger.error(&#39;{} error. {}&#39;.format(status, response.reason))
         raise APIException(&#34;{} error&#34;.format(status),
                            status_code=status,
-                           reason=response.reason)</code></pre>
+                           reason=response.reason)
+
+    def set_allowed_results_per_page(self, allowed_results_per_page):
+        self.__allowed_results_per_page = allowed_results_per_page
+
+    def get_allowed_results_per_page(self):
+        return self.__allowed_results_per_page
+    </code></pre>
 </details>
 </section>
 <section>
@@ -1125,33 +1580,35 @@ class JamaClient:
 <dl>
 <dt id="py_jama_rest_client.client.APIClientException"><code class="flex name class">
 <span>class <span class="ident">APIClientException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is thrown whenever a unknown 400 error is encountered.</p></section>
+<div class="desc"><p>This exception is thrown whenever a unknown 400 error is encountered.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class APIClientException(APIException):
     &#34;&#34;&#34;This exception is thrown whenever a unknown 400 error is encountered.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 <dt id="py_jama_rest_client.client.APIException"><code class="flex name class">
 <span>class <span class="ident">APIException</span></span>
-<span>(</span><span><small>ancestors:</small> builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This is the base class for all exceptions raised by the JamaClient</p></section>
+<div class="desc"><p>This is the base class for all exceptions raised by the JamaClient</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class APIException(Exception):
     &#34;&#34;&#34;This is the base class for all exceptions raised by the JamaClient&#34;&#34;&#34;
 
@@ -1160,89 +1617,90 @@ class JamaClient:
         self.status_code = status_code
         self.reason = reason</code></pre>
 </details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
 <h3>Subclasses</h3>
 <ul class="hlist">
-<li><a title="py_jama_rest_client.client.UnauthorizedException" href="#py_jama_rest_client.client.UnauthorizedException">UnauthorizedException</a></li>
-<li><a title="py_jama_rest_client.client.TooManyRequestsException" href="#py_jama_rest_client.client.TooManyRequestsException">TooManyRequestsException</a></li>
-<li><a title="py_jama_rest_client.client.ResourceNotFoundException" href="#py_jama_rest_client.client.ResourceNotFoundException">ResourceNotFoundException</a></li>
-<li><a title="py_jama_rest_client.client.AlreadyExistsException" href="#py_jama_rest_client.client.AlreadyExistsException">AlreadyExistsException</a></li>
 <li><a title="py_jama_rest_client.client.APIClientException" href="#py_jama_rest_client.client.APIClientException">APIClientException</a></li>
 <li><a title="py_jama_rest_client.client.APIServerException" href="#py_jama_rest_client.client.APIServerException">APIServerException</a></li>
+<li><a title="py_jama_rest_client.client.AlreadyExistsException" href="#py_jama_rest_client.client.AlreadyExistsException">AlreadyExistsException</a></li>
+<li><a title="py_jama_rest_client.client.ResourceNotFoundException" href="#py_jama_rest_client.client.ResourceNotFoundException">ResourceNotFoundException</a></li>
+<li><a title="py_jama_rest_client.client.TooManyRequestsException" href="#py_jama_rest_client.client.TooManyRequestsException">TooManyRequestsException</a></li>
+<li><a title="py_jama_rest_client.client.UnauthorizedException" href="#py_jama_rest_client.client.UnauthorizedException">UnauthorizedException</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="py_jama_rest_client.client.APIException.__init__"><code class="name flex">
-<span>def <span class="ident">__init__</span></span>(<span>self, message, status_code=None, reason=None)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Initialize self.
-See help(type(self)) for accurate signature.</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def __init__(self, message, status_code=None, reason=None):
-    super(APIException, self).__init__(message)
-    self.status_code = status_code
-    self.reason = reason</code></pre>
-</details>
-</dd>
-</dl>
 </dd>
 <dt id="py_jama_rest_client.client.APIServerException"><code class="flex name class">
 <span>class <span class="ident">APIServerException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is thrown whenever an unknown 500 response is encountered.</p></section>
+<div class="desc"><p>This exception is thrown whenever an unknown 500 response is encountered.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class APIServerException(APIException):
     &#34;&#34;&#34;This exception is thrown whenever an unknown 500 response is encountered.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 <dt id="py_jama_rest_client.client.AlreadyExistsException"><code class="flex name class">
 <span>class <span class="ident">AlreadyExistsException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is thrown when the API returns a 400 response with a message that the resource already exists.</p></section>
+<div class="desc"><p>This exception is thrown when the API returns a 400 response with a message that the resource already exists.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class AlreadyExistsException(APIException):
     &#34;&#34;&#34;This exception is thrown when the API returns a 400 response with a message that the resource already exists.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient"><code class="flex name class">
 <span>class <span class="ident">JamaClient</span></span>
+<span>(</span><span>host_domain, credentials=('username|clientID', 'password|clientSecret'), api_version='/rest/v1/', oauth=False, verify=True, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>A class to abstract communication with the Jama Connect API</p></section>
+<div class="desc"><p>A class to abstract communication with the Jama Connect API</p>
+<p>Jama Client initializer
+:rtype: JamaClient
+:param host_domain: String The domain associated with the Jama Connect host
+:param credentials: the user name and password as a tuple or client id and client secret if using Oauth.
+:param api_version: valid args are '/rest/[v1|latest|labs]/'
+:param verify: Defaults to True, Setting this to False will skip SSL Certificate verification</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class JamaClient:
     &#34;&#34;&#34;A class to abstract communication with the Jama Connect API&#34;&#34;&#34;
 
     __allowed_results_per_page = 20  # Default is 20, Max is 50. if set to greater than 50, only 50 will items return.
 
-    def __init__(self, host_domain, credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;), api_version=&#39;/rest/v1/&#39;,
-                 oauth=False, verify=True):
+    def __init__(self, host_domain,
+                 credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;),
+                 api_version=&#39;/rest/v1/&#39;,
+                 oauth=False,
+                 verify=True,
+                 allowed_results_per_page=20):
         &#34;&#34;&#34;Jama Client initializer
         :rtype: JamaClient
         :param host_domain: String The domain associated with the Jama Connect host
@@ -1250,7 +1708,12 @@ See help(type(self)) for accurate signature.</p></section>
         :param api_version: valid args are &#39;/rest/[v1|latest|labs]/&#39;
         :param verify: Defaults to True, Setting this to False will skip SSL Certificate verification&#34;&#34;&#34;
         self.__credentials = credentials
-        self.__core = Core(host_domain, credentials, api_version=api_version, oauth=oauth, verify=verify)
+        self.__allowed_results_per_page = allowed_results_per_page
+        try:
+            self.__core = Core(host_domain, credentials, api_version=api_version, oauth=oauth, verify=verify)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # Log client creation
         py_jama_rest_client_logger.info(&#39;Created a new JamaClient instance. Domain: {} &#39;
@@ -1263,21 +1726,26 @@ See help(type(self)) for accurate signature.</p></section>
         Returns: an array of available endpoints for this API
 
         &#34;&#34;&#34;
-        response = self.__core.get(&#39;&#39;)
+        try:
+            response = self.__core.get(&#39;&#39;)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_baselines(self, project_id):
+    def get_baselines(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of Baseline objects
         Args:
             project_id:  the Id of the project to fetch baselines for
+            allowed_results_per_page: number of results per page
 
         Returns: a list of Baseline objects
         &#34;&#34;&#34;
         resource_path = &#39;baselines&#39;
         params = {&#39;project&#39;: project_id}
-        baseline_data = self.__get_all(resource_path, params=params)
+        baseline_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return baseline_data
 
     def get_baseline(self, baseline_id):
@@ -1290,37 +1758,42 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;baselines/&#39; + str(baseline_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_baselines_versioneditems(self, baseline_id):
+    def get_baselines_versioneditems(self, baseline_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all baseline items in a baseline with the specified ID
         Args:
             baseline_id:  The id of the baseline to fetch items for.
-
+            allowed_results_per_page: Number of results per page
         Returns: A list of versioned items belonging to the baseline
         &#34;&#34;&#34;
         resource_path = &#39;baselines/&#39; + str(baseline_id) + &#39;/versioneditems&#39;
-        baseline_items = self.__get_all(resource_path)
+        baseline_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return baseline_items
 
-    def get_projects(self):
+    def get_projects(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;This method will return all projects as JSON object
         :return: JSON Array of Item Objects.
         &#34;&#34;&#34;
         resource_path = &#39;projects&#39;
-        project_data = self.__get_all(resource_path)
+        project_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return project_data
 
-    def get_filter_results(self, filter_id, project_id=None):
+    def get_filter_results(self, filter_id, project_id=None, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all results items for the filter with the specified ID
 
         Args:
             filter_id: The ID of the filter to fetch the results for.
             project_id: Use this only for filters that run on any project, where projectScope is CURRENT
+            allowed_results_per_page: Number of results per page
 
         Returns:
             A List of items that match the filter.
@@ -1330,21 +1803,22 @@ See help(type(self)) for accurate signature.</p></section>
         params = None
         if project_id is not None:
             params = {&#39;project&#39;: str(project_id)}
-        filter_results = self.__get_all(resource_path, params=params)
+        filter_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return filter_results
 
-    def get_items(self, project_id):
+    def get_items(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all items in the specified project.
         Args:
             project_id: the project ID
+            allowed_results_per_page: number of results per page
 
         Returns: a Json array of item objects
 
         &#34;&#34;&#34;
         resource_path = &#39;items&#39;
         params = {&#39;project&#39;: project_id}
-        item_data = self.__get_all(resource_path, params=params)
+        item_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return item_data
 
     def get_item(self, item_id):
@@ -1357,7 +1831,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -1372,7 +1850,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -1392,8 +1874,27 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
+
+    def get_item_tags(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+        &#34;&#34;&#34;
+        Return all tags for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            allowed_results_per_page: number of results
+
+        Returns: a dictionary object representing the item&#39;s tags
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
+        item_tags = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+        return item_tags
 
     def get_attachment(self, attachment_id):
         &#34;&#34;&#34;
@@ -1405,28 +1906,69 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;attachments/&#39; + str(attachment_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_abstract_items_from_doc_key(self, doc_key_list):
+    def get_abstract_items_from_doc_key(self, doc_key_list, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34; DEPRECATED INSTEAD USE get_abstract_items below.
         This method will take in a list of document keys and return an array of JSON Objects associated with the
         document keys.&#34;&#34;&#34;
         resource_path = &#39;abstractitems&#39;
         params = {&#39;documentKey&#39;: doc_key_list}
-        abstract_items = self.__get_all(resource_path, params=params)
+        abstract_items = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return abstract_items
 
-    def get_relationship_types(self):
+    def get_relationship_rule_sets(self):
+        &#34;&#34;&#34;
+        This method will return all relationship rule sets across all projects of the Jama Connect instance.
+
+        Returns: An array of dictionary objects representing a rule set and its associated rules
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39;
+        rule_sets = self.__get_all(resource_path)
+        return rule_sets
+
+    def get_relationship_rule_set(self, id):
+        &#34;&#34;&#34;
+        This method will return the relationship rule sets by id.
+
+        Returns: A dictionary object representing a rule set and its associated rules
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39; + str(id)
+        response = self.__core.get(resource_path)
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_relationship_rule_set_projects(self, id):
+        &#34;&#34;&#34;
+        This method will return the projects that have a given relationship rule set defined.
+
+        Returns: An array of the dictionary objects representing the projects with a given rule set assigned
+
+        &#34;&#34;&#34;
+        resource_path = &#39;relationshiprulesets/&#39; + str(id) + &#39;/projects&#39;
+        projects = self.__get_all(resource_path)
+        return projects
+
+    def get_relationship_types(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all relationship types of the across all projects of the Jama Connect instance.
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: An array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;relationshiptypes/&#39;
-        item_types = self.__get_all(resource_path)
+        item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return item_types
 
     def get_relationship_type(self, relationship_type_id):
@@ -1440,19 +1982,26 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;relationshiptypes/&#39; + str(relationship_type_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_item_types(self):
+    def get_item_types(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return all item types of the across all projects of the Jama Connect instance.
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: An array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;itemtypes/&#39;
-        item_types = self.__get_all(resource_path)
+        item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return item_types
 
     def get_item_type(self, item_type_id):
@@ -1466,23 +2015,28 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;itemtypes/&#39; + str(item_type_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_items_synceditems(self, item_id):
+    def get_items_synceditems(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all synchronized items for the item with the specified ID
 
         Args:
             item_id: The API id of the item being
+            allowed_results_per_page: Number of results per page
 
         Returns: A list of JSON Objects representing the items that are in the same synchronization group as the
         specified item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems&#39;
-        synced_items = self.__get_all(resource_path)
+        synced_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return synced_items
 
     def get_items_synceditems_status(self, item_id, synced_item_id):
@@ -1497,19 +2051,121 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems/&#39; + str(synced_item_id) + &#39;/syncstatus&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_item_versions(self, item_id):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path)
+        return versions
+
+    def get_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_item_versions(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            allowed_results_per_page: number of results per page
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+        return versions
+
+    def get_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
         response = self.__core.get(resource_path)
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_pick_lists(self):
+    def get_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        response = self.__core.get(resource_path)
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_pick_lists(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the pick lists
+
+        Args:
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39;
-        pick_lists = self.__get_all(resource_path)
+        pick_lists = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return pick_lists
 
     def get_pick_list(self, pick_list_id):
@@ -1523,21 +2179,26 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39; + str(pick_list_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_pick_list_options(self, pick_list_id):
+    def get_pick_list_options(self, pick_list_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Gets all all the picklist options for a single picklist
         Args:
             pick_list_id: the api id of the picklist to fetch options for.
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the picklist options.
 
         &#34;&#34;&#34;
         resource_path = &#39;picklists/&#39; + str(pick_list_id) + &#39;/options&#39;
-        pick_list_options = self.__get_all(resource_path)
+        pick_list_options = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return pick_list_options
 
     def get_pick_list_option(self, pick_list_option_id):
@@ -1550,23 +2211,29 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;picklistoptions/&#39; + str(pick_list_option_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
-    def get_relationships(self, project_id):
+    def get_relationships(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all relationships of a specified project
 
         Args:
             project_id: the api project id of a project
+            allowed_results_per_page: number of results per page
 
         Returns: a list of dictionary objects that represents a relationships
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships&#39;
         params = {&#39;project&#39;: project_id}
-        relationship_data = self.__get_all(resource_path, params=params)
+        relationship_data = self.__get_all(resource_path, params=params,
+                                           allowed_results_per_page=allowed_results_per_page)
         return relationship_data
 
     def get_relationship(self, relationship_id):
@@ -1580,7 +2247,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships/&#39; + str(relationship_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -1647,51 +2318,124 @@ See help(type(self)) for accurate signature.</p></section>
         abstract_items = self.__get_all(resource_path, params=params)
         return abstract_items
 
-    def get_item_children(self, item_id):
+    def get_abstract_item(self, item_id):
+        &#34;&#34;&#34;
+        This method will return an item, test plan, test cycle, test run, or attachment with the specified ID
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: a dictonary object representing the abstract item
+
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_abstract_item_versions(self, item_id):
+        &#34;&#34;&#34;
+        Get all versions for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+
+        Returns: JSON array with all versions for the item
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions&#39;
+        versions = self.__get_all(resource_path)
+        return versions
+
+    def get_abtract_item_version(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the numbered version for the item with the specified ID
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the numbered version
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_abstract_versioned_item(self, item_id, version_num):
+        &#34;&#34;&#34;
+        Get the snapshot of the item at the specified version
+
+        Args:
+            item_id: the item id of the item to fetch
+            version_num: the version number for the item
+
+        Returns: a dictionary object representing the versioned item
+        &#34;&#34;&#34;
+        resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+
+    def get_item_children(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         This method will return list of the child items of the item passed to the function.
         Args:
             item_id: (int) The id of the item for which children items should be fetched
+            allowed_results_per_page: Number of results per page
 
         Returns: a List of Objects that represent the children of the item passed in.
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/children&#39;
-        child_items = self.__get_all(resource_path)
+        child_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return child_items
 
-    def get_testruns(self, test_cycle_id):
+    def get_testruns(self, test_cycle_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;This method will return all test runs associated with the specified test cycle.  Test runs will be returned
         as a list of json objects.&#34;&#34;&#34;
         resource_path = &#39;testcycles/&#39; + str(test_cycle_id) + &#39;/testruns&#39;
-        testrun_data = self.__get_all(resource_path)
+        testrun_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return testrun_data
 
-    def get_items_upstream_relationships(self, item_id):
+    def get_items_upstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the upstream relationships for the item with the specified ID.
         Args:
             item_id: the api id of the item
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the upstream relationships for the item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelationships&#39;
-        return self.__get_all(resource_path)
+        return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
 
-    def get_items_downstream_related(self, item_id):
+    def get_items_downstream_related(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the downstream related items for the item with the specified ID.
 
         Args:
             item_id: the api id of the item to fetch downstream items for
+            allowed_results_per_page: number of results per page
 
         Returns: an array of dictionary objects that represent the downstream related items for the specified item.
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelated&#39;
-        return self.__get_all(resource_path)
+        return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
 
-    def get_items_downstream_relationships(self, item_id):
+    def get_items_downstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Returns a list of all the downstream relationships for the item with the specified ID.
 
@@ -1702,28 +2446,57 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelationships&#39;
+        return self.__get_all(resource_path, allowed_results_per_page=allowed_results_per_page)
+
+    def get_items_upstream_related(self, item_id):
+        &#34;&#34;&#34;
+        Returns a list of all the upstream related items for the item with the specified ID.
+
+        Args:
+            item_id: the api id of the item to fetch upstream items for
+
+        Returns: an array of dictionary objects that represent the upstream related items for the specified item.
+
+         &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelated&#39;
         return self.__get_all(resource_path)
 
-    def get_tags(self, project):
+    def get_item_workflow_transitions(self, item_id):
+        &#34;&#34;&#34;
+        Get all valid workflow transitions that can be made with the specified id
+
+        Args:
+            item_id: the api id of the item
+            allowed_results_per_page: number of results per page
+
+        Returns: an array of dictionary objects that represent the workflow transitions for the item.
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/workflowtransitionoptions&#39;
+        return self.__get_all(resource_path)
+
+    def get_tags(self, project, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all tags for the project with the specified id
         Args:
             project: The API ID of the project to fetch tags for.
+            allowed_results_per_page: Number of results per page
 
         Returns: A Json Array that contains all the tag data for the specified project.
 
         &#34;&#34;&#34;
         resource_path = &#39;tags&#39;
         params = {&#39;project&#39;: project}
-        tag_data = self.__get_all(resource_path, params=params)
+        tag_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return tag_data
 
-    def get_tagged_items(self, tag_id):
+    def get_tagged_items(self, tag_id, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Get all items tagged with the specified ID
 
         Args:
             tag_id: The ID of the tag to fetch the results for.
+            allowed_results_per_page: Number of results per page
 
         Returns:
             A List of items that match the tag.
@@ -1731,18 +2504,57 @@ See help(type(self)) for accurate signature.</p></section>
         &#34;&#34;&#34;
         resource_path = &#39;tags/&#39; + str(tag_id) + &#39;/items&#39;
         params = None
-        tag_results = self.__get_all(resource_path, params=params)
+        tag_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return tag_results
 
-    def get_users(self):
+    def get_item_links(self, item_id):
+        &#34;&#34;&#34;
+        This method will return all links in the specified item.
+        Args:
+            item_id: the item ID
+
+        Returns: a Json object with the links present in the item specified
+
+        &#34;&#34;&#34;
+        resource_path = &#39;items/&#39; + str(item_id) + &#39;/links&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_filter_results_count(self, filter_id):
+        &#34;&#34;&#34;
+        This method will return count of items found through the specified filter.
+        Args:
+            filter_id: the filter ID
+
+        Returns: a count of the items matched with the filter
+
+        &#34;&#34;&#34;
+        resource_path = &#39;filters/&#39; + str(filter_id) + &#39;/count&#39;
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()[&#39;data&#39;]
+
+    def get_users(self, allowed_results_per_page=__allowed_results_per_page):
         &#34;&#34;&#34;
         Gets a list of all active users visible to the current user
+
+        Args:
+            allowed_results_per_page: Number of results per page
 
         Returns: JSON array
 
         &#34;&#34;&#34;
         resource_path = &#39;users/&#39;
-        users = self.__get_all(resource_path)
+        users = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
         return users
 
     def get_user(self, user_id):
@@ -1756,7 +2568,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;users/&#39; + str(user_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return response.json()[&#39;data&#39;]
 
     def get_current_user(self):
@@ -1767,7 +2583,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;users/current&#39;
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return response.json()[&#39;data&#39;]
 
     def get_test_cycle(self, test_cycle_id):
@@ -1781,7 +2601,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;testcycles/&#39; + str(test_cycle_id)
-        response = self.__core.get(resource_path)
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;data&#39;]
 
@@ -1795,7 +2619,11 @@ See help(type(self)) for accurate signature.</p></section>
         Returns: The success status code.
         &#34;&#34;&#34;
         resource_path = &#39;items/&#39; + str(item_id)
-        response = self.__core.delete(resource_path)
+        try:
+            response = self.__core.delete(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -1810,7 +2638,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         &#34;&#34;&#34;
         resource_path = &#39;relationships/&#39; + str(relationship_id)
-        response = self.__core.delete(resource_path)
+        try:
+            response = self.__core.delete(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -1838,7 +2670,11 @@ See help(type(self)) for accurate signature.</p></section>
         data = json.dumps(patches)
 
         # Make the API Call
-        response = self.__core.patch(resource_path, data=data, headers=headers)
+        try:
+            response = self.__core.patch(resource_path, data=data, headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # validate response
         JamaClient.__handle_response_status(response)
@@ -1877,7 +2713,11 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;users/&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -1896,7 +2736,11 @@ See help(type(self)) for accurate signature.</p></section>
             &#39;project&#39;: project
         }
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -1936,7 +2780,11 @@ See help(type(self)) for accurate signature.</p></section>
         }
 
         # Make the API Call
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
 
         # Validate response
         JamaClient.__handle_response_status(response)
@@ -1970,7 +2818,11 @@ See help(type(self)) for accurate signature.</p></section>
             params[&#39;setGlobalIdManually&#39;] = True
 
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -1989,7 +2841,11 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -2009,7 +2865,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         resource_path = &#39;items/&#39; + str(pool_item) + &#39;/synceditems&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -2032,7 +2892,11 @@ See help(type(self)) for accurate signature.</p></section>
             body[&#39;relationshipType&#39;] = relationship_type
         resource_path = &#39;relationships/&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -2046,7 +2910,11 @@ See help(type(self)) for accurate signature.</p></section>
         body = {&#34;attachment&#34;: attachment_id}
         resource_path = &#39;items/&#39; + str(item_id) + &#39;/attachments&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.status_code
 
@@ -2067,7 +2935,11 @@ See help(type(self)) for accurate signature.</p></section>
 
         resource_path = &#39;projects/&#39; + str(project_id) + &#39;/attachments&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response.json()[&#39;meta&#39;][&#39;id&#39;]
 
@@ -2093,7 +2965,11 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;items/&#39; + str(item_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
     def put_attachments_file(self, attachment_id, file_path):
@@ -2106,8 +2982,11 @@ See help(type(self)) for accurate signature.</p></section>
         resource_path = &#39;attachments/&#39; + str(attachment_id) + &#39;/file&#39;
         with open(file_path, &#39;rb&#39;) as f:
             files = {&#39;file&#39;: f}
-            response = self.__core.put(resource_path, files=files)
-
+            try:
+                response = self.__core.put(resource_path, files=files)
+            except CoreException as err:
+                py_jama_rest_client_logger.error(err)
+                raise APIException(str(err))
         self.__handle_response_status(response)
         return response.status_code
 
@@ -2142,7 +3021,12 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;users/&#39; + str(user_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+            raise APIException
         return self.__handle_response_status(response)
 
     def put_user_active(self, user_id, is_active):
@@ -2160,54 +3044,68 @@ See help(type(self)) for accurate signature.</p></section>
         }
         resource_path = &#39;users/&#39; + str(user_id) + &#39;/active&#39;
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
     def put_test_run(self, test_run_id, data=None):
         &#34;&#34;&#34; This method will post a test run to Jama through the API&#34;&#34;&#34;
         resource_path = &#39;testruns/&#39; + str(test_run_id)
         headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-        response = self.__core.put(resource_path, data=data, headers=headers)
+        try:
+            response = self.__core.put(resource_path, data=data, headers=headers)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         return self.__handle_response_status(response)
 
-    def __get_all(self, resource, params=None, **kwargs):
+    def __get_all(self, resource, params=None, allowed_results_per_page=__allowed_results_per_page, **kwargs):
         &#34;&#34;&#34;This method will get all of the resources specified by the resource parameter, if an id or some other
         parameter is required for the resource, include it in the params parameter.
         Returns a single JSON array with all of the retrieved items.&#34;&#34;&#34;
 
+        if allowed_results_per_page &lt; 1 or allowed_results_per_page &gt; 50:
+            raise ValueError(&#34;Allowed results per page must be between 1 and 50&#34;)
+
         start_index = 0
-        result_count = -1
         allowed_results_per_page = 20
+        total_results = float(&#34;inf&#34;)
 
         data = []
 
-        while result_count != 0:
+        while len(data) &lt; total_results:
             page_response = self.__get_page(resource, start_index, params=params, **kwargs)
             page_json = page_response.json()
 
             page_info = page_json[&#39;meta&#39;][&#39;pageInfo&#39;]
             start_index = page_info[&#39;startIndex&#39;] + allowed_results_per_page
-            result_count = page_info[&#39;resultCount&#39;]
-
+            total_results = page_info.get(&#39;totalResults&#39;)
             page_data = page_json.get(&#39;data&#39;)
             data.extend(page_data)
 
         return data
 
-    def __get_page(self, resource, start_at, params=None, **kwargs):
+    def __get_page(self, resource, start_at, params=None,  allowed_results_per_page=__allowed_results_per_page,  **kwargs):
         &#34;&#34;&#34;This method will return one page of results from the specified resource type.
         Pass any needed parameters along
         The response object will be returned&#34;&#34;&#34;
         parameters = {
             &#39;startAt&#39;: start_at,
-            &#39;maxResults&#39;: self.__allowed_results_per_page
+            &#39;maxResults&#39;: allowed_results_per_page
         }
 
         if params is not None:
             for k, v in params.items():
                 parameters[k] = v
 
-        response = self.__core.get(resource, params=parameters, **kwargs)
+        try:
+            response = self.__core.get(resource, params=parameters, **kwargs)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
         JamaClient.__handle_response_status(response)
         return response
 
@@ -2277,51 +3175,31 @@ See help(type(self)) for accurate signature.</p></section>
         py_jama_rest_client_logger.error(&#39;{} error. {}&#39;.format(status, response.reason))
         raise APIException(&#34;{} error&#34;.format(status),
                            status_code=status,
-                           reason=response.reason)</code></pre>
+                           reason=response.reason)
+
+    def set_allowed_results_per_page(self, allowed_results_per_page):
+        self.__allowed_results_per_page = allowed_results_per_page
+
+    def get_allowed_results_per_page(self):
+        return self.__allowed_results_per_page</code></pre>
 </details>
 <h3>Methods</h3>
 <dl>
-<dt id="py_jama_rest_client.client.JamaClient.__init__"><code class="name flex">
-<span>def <span class="ident">__init__</span></span>(<span>self, host_domain, credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;), api_version=&#39;/rest/v1/&#39;, oauth=False, verify=True)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Jama Client initializer
-:rtype: JamaClient
-:param host_domain: String The domain associated with the Jama Connect host
-:param credentials: the user name and password as a tuple or client id and client secret if using Oauth.
-:param api_version: valid args are '/rest/[v1|latest|labs]/'
-:param verify: Defaults to True, Setting this to False will skip SSL Certificate verification</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def __init__(self, host_domain, credentials=(&#39;username|clientID&#39;, &#39;password|clientSecret&#39;), api_version=&#39;/rest/v1/&#39;,
-             oauth=False, verify=True):
-    &#34;&#34;&#34;Jama Client initializer
-    :rtype: JamaClient
-    :param host_domain: String The domain associated with the Jama Connect host
-    :param credentials: the user name and password as a tuple or client id and client secret if using Oauth.
-    :param api_version: valid args are &#39;/rest/[v1|latest|labs]/&#39;
-    :param verify: Defaults to True, Setting this to False will skip SSL Certificate verification&#34;&#34;&#34;
-    self.__credentials = credentials
-    self.__core = Core(host_domain, credentials, api_version=api_version, oauth=oauth, verify=verify)
-
-    # Log client creation
-    py_jama_rest_client_logger.info(&#39;Created a new JamaClient instance. Domain: {} &#39;
-                                    &#39;Connecting via Oauth: {}&#39;.format(host_domain, oauth))</code></pre>
-</details>
-</dd>
 <dt id="py_jama_rest_client.client.JamaClient.delete_item"><code class="name flex">
 <span>def <span class="ident">delete_item</span></span>(<span>self, item_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will delete an item in Jama Connect.</p>
+<div class="desc"><p>This method will delete an item in Jama Connect.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>The jama connect API ID of the item to be deleted</dd>
 </dl>
-<p>Returns: The success status code.</p></section>
+<p>Returns: The success status code.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def delete_item(self, item_id):
     &#34;&#34;&#34;
     This method will delete an item in Jama Connect.
@@ -2332,7 +3210,11 @@ See help(type(self)) for accurate signature.</p></section>
     Returns: The success status code.
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id)
-    response = self.__core.delete(resource_path)
+    try:
+        response = self.__core.delete(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.status_code</code></pre>
 </details>
@@ -2341,15 +3223,17 @@ See help(type(self)) for accurate signature.</p></section>
 <span>def <span class="ident">delete_relationships</span></span>(<span>self, relationship_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Deletes a relationship with the specified relationship ID</p>
+<div class="desc"><p>Deletes a relationship with the specified relationship ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>relationship_id</code></strong></dt>
 <dd>the api project id of a relationship</dd>
 </dl>
-<p>Returns: The success status code.</p></section>
+<p>Returns: The success status code.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def delete_relationships(self, relationship_id):
     &#34;&#34;&#34;
     Deletes a relationship with the specified relationship ID
@@ -2361,16 +3245,83 @@ See help(type(self)) for accurate signature.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;relationships/&#39; + str(relationship_id)
-    response = self.__core.delete(resource_path)
+    try:
+        response = self.__core.delete(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.status_code</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_abstract_item"><code class="name flex">
+<span>def <span class="ident">get_abstract_item</span></span>(<span>self, item_id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return an item, test plan, test cycle, test run, or attachment with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+</dl>
+<p>Returns: a dictonary object representing the abstract item</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_abstract_item(self, item_id):
+    &#34;&#34;&#34;
+    This method will return an item, test plan, test cycle, test run, or attachment with the specified ID
+    Args:
+        item_id: the item id of the item to fetch
+
+    Returns: a dictonary object representing the abstract item
+
+    &#34;&#34;&#34;
+    resource_path = &#39;abstractitems/&#39; + str(item_id)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_abstract_item_versions"><code class="name flex">
+<span>def <span class="ident">get_abstract_item_versions</span></span>(<span>self, item_id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get all versions for the item with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+</dl>
+<p>Returns: JSON array with all versions for the item</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_abstract_item_versions(self, item_id):
+    &#34;&#34;&#34;
+    Get all versions for the item with the specified ID
+
+    Args:
+        item_id: the item id of the item to fetch
+
+    Returns: JSON array with all versions for the item
+    &#34;&#34;&#34;
+    resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions&#39;
+    versions = self.__get_all(resource_path)
+    return versions</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_abstract_items"><code class="name flex">
 <span>def <span class="ident">get_abstract_items</span></span>(<span>self, project=None, item_type=None, document_key=None, release=None, created_date=None, modified_date=None, last_activity_date=None, contains=None, sort_by=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all items that match the query parameters entered.</p>
+<div class="desc"><p>This method will return all items that match the query parameters entered.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>project</code></strong></dt>
@@ -2414,9 +3365,11 @@ See help(type(self)) for accurate signature.</p></section>
 </dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A JSON Array of items.</p></section>
+<p>A JSON Array of items.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_abstract_items(self,
                        project=None,
                        item_type=None,
@@ -2482,38 +3435,128 @@ See help(type(self)) for accurate signature.</p></section>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_abstract_items_from_doc_key"><code class="name flex">
-<span>def <span class="ident">get_abstract_items_from_doc_key</span></span>(<span>self, doc_key_list)</span>
+<span>def <span class="ident">get_abstract_items_from_doc_key</span></span>(<span>self, doc_key_list, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>DEPRECATED INSTEAD USE get_abstract_items below.
+<div class="desc"><p>DEPRECATED INSTEAD USE get_abstract_items below.
 This method will take in a list of document keys and return an array of JSON Objects associated with the
-document keys.</p></section>
+document keys.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_abstract_items_from_doc_key(self, doc_key_list):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_abstract_items_from_doc_key(self, doc_key_list, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34; DEPRECATED INSTEAD USE get_abstract_items below.
     This method will take in a list of document keys and return an array of JSON Objects associated with the
     document keys.&#34;&#34;&#34;
     resource_path = &#39;abstractitems&#39;
     params = {&#39;documentKey&#39;: doc_key_list}
-    abstract_items = self.__get_all(resource_path, params=params)
+    abstract_items = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return abstract_items</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_abstract_versioned_item"><code class="name flex">
+<span>def <span class="ident">get_abstract_versioned_item</span></span>(<span>self, item_id, version_num)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the snapshot of the item at the specified version</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>version_num</code></strong></dt>
+<dd>the version number for the item</dd>
+</dl>
+<p>Returns: a dictionary object representing the versioned item</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_abstract_versioned_item(self, item_id, version_num):
+    &#34;&#34;&#34;
+    Get the snapshot of the item at the specified version
+
+    Args:
+        item_id: the item id of the item to fetch
+        version_num: the version number for the item
+
+    Returns: a dictionary object representing the versioned item
+    &#34;&#34;&#34;
+    resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_abtract_item_version"><code class="name flex">
+<span>def <span class="ident">get_abtract_item_version</span></span>(<span>self, item_id, version_num)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the numbered version for the item with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>version_num</code></strong></dt>
+<dd>the version number for the item</dd>
+</dl>
+<p>Returns: a dictionary object representing the numbered version</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_abtract_item_version(self, item_id, version_num):
+    &#34;&#34;&#34;
+    Get the numbered version for the item with the specified ID
+
+    Args:
+        item_id: the item id of the item to fetch
+        version_num: the version number for the item
+
+    Returns: a dictionary object representing the numbered version
+    &#34;&#34;&#34;
+    resource_path = &#39;abstractitems/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_allowed_results_per_page"><code class="name flex">
+<span>def <span class="ident">get_allowed_results_per_page</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_allowed_results_per_page(self):
+    return self.__allowed_results_per_page</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_attachment"><code class="name flex">
 <span>def <span class="ident">get_attachment</span></span>(<span>self, attachment_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return a singular attachment of a specified attachment id</p>
+<div class="desc"><p>This method will return a singular attachment of a specified attachment id</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>attachment_id</code></strong></dt>
 <dd>the attachment id of the attachment to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>dictonary</code> <code>object</code> <code>representing</code> <code>the</code> <code>attachment</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: a dictonary object representing the attachment</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_attachment(self, attachment_id):
     &#34;&#34;&#34;
     This method will return a singular attachment of a specified attachment id
@@ -2524,7 +3567,11 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;attachments/&#39; + str(attachment_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
@@ -2533,13 +3580,12 @@ document keys.</p></section>
 <span>def <span class="ident">get_available_endpoints</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all the available endpoints.</p>
-<dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>an</code> <code>array</code> of <code>available</code> <code>endpoints</code> <code>for</code> <code>this</code> <code>API</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<div class="desc"><p>Returns a list of all the available endpoints.</p>
+<p>Returns: an array of available endpoints for this API</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_available_endpoints(self):
     &#34;&#34;&#34;
     Returns a list of all the available endpoints.
@@ -2547,7 +3593,11 @@ document keys.</p></section>
     Returns: an array of available endpoints for this API
 
     &#34;&#34;&#34;
-    response = self.__core.get(&#39;&#39;)
+    try:
+        response = self.__core.get(&#39;&#39;)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
@@ -2556,16 +3606,17 @@ document keys.</p></section>
 <span>def <span class="ident">get_baseline</span></span>(<span>self, baseline_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return a baseline</p>
+<div class="desc"><p>This method will return a baseline</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>baseline_id</code></strong></dt>
 <dd>the id of the baseline to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>dictionary</code> <code>object</code> <code>representing</code> <code>the</code> <code>baseline</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: a dictionary object representing the baseline</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_baseline(self, baseline_id):
     &#34;&#34;&#34;
     This method will return a baseline
@@ -2576,63 +3627,74 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;baselines/&#39; + str(baseline_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_baselines"><code class="name flex">
-<span>def <span class="ident">get_baselines</span></span>(<span>self, project_id)</span>
+<span>def <span class="ident">get_baselines</span></span>(<span>self, project_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of Baseline objects</p>
+<div class="desc"><p>Returns a list of Baseline objects</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>project_id</code></strong></dt>
 <dd>the Id of the project to fetch baselines for</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>list</code> of <code>Baseline</code> <code>objects</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: a list of Baseline objects</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_baselines(self, project_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_baselines(self, project_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of Baseline objects
     Args:
         project_id:  the Id of the project to fetch baselines for
+        allowed_results_per_page: number of results per page
 
     Returns: a list of Baseline objects
     &#34;&#34;&#34;
     resource_path = &#39;baselines&#39;
     params = {&#39;project&#39;: project_id}
-    baseline_data = self.__get_all(resource_path, params=params)
+    baseline_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return baseline_data</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_baselines_versioneditems"><code class="name flex">
-<span>def <span class="ident">get_baselines_versioneditems</span></span>(<span>self, baseline_id)</span>
+<span>def <span class="ident">get_baselines_versioneditems</span></span>(<span>self, baseline_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all baseline items in a baseline with the specified ID</p>
+<div class="desc"><p>Get all baseline items in a baseline with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>baseline_id</code></strong></dt>
 <dd>The id of the baseline to fetch items for.</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>A</code> <code>list</code> of <code>versioned</code> <code>items</code> <code>belonging</code> <code>to</code> <code>the</code> <code>baseline</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
+</dl>
+<p>Returns: A list of versioned items belonging to the baseline</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_baselines_versioneditems(self, baseline_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_baselines_versioneditems(self, baseline_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Get all baseline items in a baseline with the specified ID
     Args:
         baseline_id:  The id of the baseline to fetch items for.
-
+        allowed_results_per_page: Number of results per page
     Returns: A list of versioned items belonging to the baseline
     &#34;&#34;&#34;
     resource_path = &#39;baselines/&#39; + str(baseline_id) + &#39;/versioneditems&#39;
-    baseline_items = self.__get_all(resource_path)
+    baseline_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return baseline_items</code></pre>
 </details>
 </dd>
@@ -2640,13 +3702,12 @@ document keys.</p></section>
 <span>def <span class="ident">get_current_user</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets a current user</p>
-<dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>JSON</code> <code>obect</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<div class="desc"><p>Gets a current user</p>
+<p>Returns: JSON obect</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_current_user(self):
     &#34;&#34;&#34;
     Gets a current user
@@ -2655,33 +3716,42 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;users/current&#39;
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_filter_results"><code class="name flex">
-<span>def <span class="ident">get_filter_results</span></span>(<span>self, filter_id, project_id=None)</span>
+<span>def <span class="ident">get_filter_results</span></span>(<span>self, filter_id, project_id=None, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all results items for the filter with the specified ID</p>
+<div class="desc"><p>Get all results items for the filter with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>filter_id</code></strong></dt>
 <dd>The ID of the filter to fetch the results for.</dd>
 <dt><strong><code>project_id</code></strong></dt>
 <dd>Use this only for filters that run on any project, where projectScope is CURRENT</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A List of items that match the filter.</p></section>
+<p>A List of items that match the filter.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_filter_results(self, filter_id, project_id=None):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_filter_results(self, filter_id, project_id=None, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Get all results items for the filter with the specified ID
 
     Args:
         filter_id: The ID of the filter to fetch the results for.
         project_id: Use this only for filters that run on any project, where projectScope is CURRENT
+        allowed_results_per_page: Number of results per page
 
     Returns:
         A List of items that match the filter.
@@ -2691,24 +3761,59 @@ document keys.</p></section>
     params = None
     if project_id is not None:
         params = {&#39;project&#39;: str(project_id)}
-    filter_results = self.__get_all(resource_path, params=params)
+    filter_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return filter_results</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_filter_results_count"><code class="name flex">
+<span>def <span class="ident">get_filter_results_count</span></span>(<span>self, filter_id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return count of items found through the specified filter.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>filter_id</code></strong></dt>
+<dd>the filter ID</dd>
+</dl>
+<p>Returns: a count of the items matched with the filter</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_filter_results_count(self, filter_id):
+    &#34;&#34;&#34;
+    This method will return count of items found through the specified filter.
+    Args:
+        filter_id: the filter ID
+
+    Returns: a count of the items matched with the filter
+
+    &#34;&#34;&#34;
+    resource_path = &#39;filters/&#39; + str(filter_id) + &#39;/count&#39;
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_item"><code class="name flex">
 <span>def <span class="ident">get_item</span></span>(<span>self, item_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return a singular item of a specified item id</p>
+<div class="desc"><p>This method will return a singular item of a specified item id</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>the item id of the item to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>dictonary</code> <code>object</code> <code>representing</code> <code>the</code> <code>item</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: a dictonary object representing the item</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_item(self, item_id):
     &#34;&#34;&#34;
     This method will return a singular item of a specified item id
@@ -2719,51 +3824,96 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_item_children"><code class="name flex">
-<span>def <span class="ident">get_item_children</span></span>(<span>self, item_id)</span>
+<span>def <span class="ident">get_item_children</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return list of the child items of the item passed to the function.</p>
+<div class="desc"><p>This method will return list of the child items of the item passed to the function.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>(int) The id of the item for which children items should be fetched</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
 </dl>
-<p>Returns: a List of Objects that represent the children of the item passed in.</p></section>
+<p>Returns: a List of Objects that represent the children of the item passed in.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_item_children(self, item_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_children(self, item_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     This method will return list of the child items of the item passed to the function.
     Args:
         item_id: (int) The id of the item for which children items should be fetched
+        allowed_results_per_page: Number of results per page
 
     Returns: a List of Objects that represent the children of the item passed in.
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/children&#39;
-    child_items = self.__get_all(resource_path)
+    child_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return child_items</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_item_links"><code class="name flex">
+<span>def <span class="ident">get_item_links</span></span>(<span>self, item_id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return all links in the specified item.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item ID</dd>
+</dl>
+<p>Returns: a Json object with the links present in the item specified</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_links(self, item_id):
+    &#34;&#34;&#34;
+    This method will return all links in the specified item.
+    Args:
+        item_id: the item ID
+
+    Returns: a Json object with the links present in the item specified
+
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/links&#39;
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_item_lock"><code class="name flex">
 <span>def <span class="ident">get_item_lock</span></span>(<span>self, item_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get the locked state, last locked date, and last locked by user for the item with the specified ID</p>
+<div class="desc"><p>Get the locked state, last locked date, and last locked by user for the item with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>The API ID of the item to get the lock info for.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A JSON object with the lock information for the item with the specified ID.</p></section>
+<p>A JSON object with the lock information for the item with the specified ID.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_item_lock(self, item_id):
     &#34;&#34;&#34;
     Get the locked state, last locked date, and last locked by user for the item with the specified ID
@@ -2775,25 +3925,63 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_item_tags"><code class="name flex">
+<span>def <span class="ident">get_item_tags</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return all tags for the item with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results</dd>
+</dl>
+<p>Returns: a dictionary object representing the item's tags</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_tags(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+    &#34;&#34;&#34;
+    Return all tags for the item with the specified ID
+
+    Args:
+        item_id: the item id of the item to fetch
+        allowed_results_per_page: number of results
+
+    Returns: a dictionary object representing the item&#39;s tags
+
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
+    item_tags = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+    return item_tags</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_item_type"><code class="name flex">
 <span>def <span class="ident">get_item_type</span></span>(<span>self, item_type_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets item type information for a specific item type id.</p>
+<div class="desc"><p>Gets item type information for a specific item type id.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_type_id</code></strong></dt>
 <dd>The api id of the item type to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>JSON</code> <code>object</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: JSON object</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_item_type(self, item_type_id):
     &#34;&#34;&#34;
     Gets item type information for a specific item type id.
@@ -2805,104 +3993,223 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;itemtypes/&#39; + str(item_type_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_item_types"><code class="name flex">
-<span>def <span class="ident">get_item_types</span></span>(<span>self)</span>
+<span>def <span class="ident">get_item_types</span></span>(<span>self, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all item types of the across all projects of the Jama Connect instance.</p>
+<div class="desc"><p>This method will return all item types of the across all projects of the Jama Connect instance.</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>An</code> <code>array</code> of <code>dictionary</code> <code>objects</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
+</dl>
+<p>Returns: An array of dictionary objects</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_item_types(self):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_types(self, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     This method will return all item types of the across all projects of the Jama Connect instance.
+
+    Args:
+        allowed_results_per_page: Number of results per page
 
     Returns: An array of dictionary objects
 
     &#34;&#34;&#34;
     resource_path = &#39;itemtypes/&#39;
-    item_types = self.__get_all(resource_path)
+    item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return item_types</code></pre>
 </details>
 </dd>
-<dt id="py_jama_rest_client.client.JamaClient.get_items"><code class="name flex">
-<span>def <span class="ident">get_items</span></span>(<span>self, project_id)</span>
+<dt id="py_jama_rest_client.client.JamaClient.get_item_version"><code class="name flex">
+<span>def <span class="ident">get_item_version</span></span>(<span>self, item_id, version_num)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all items in the specified project.</p>
+<div class="desc"><p>Get the numbered version for the item with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>version_num</code></strong></dt>
+<dd>the version number for the item</dd>
+</dl>
+<p>Returns: a dictionary object representing the numbered version</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_version(self, item_id, version_num):
+    &#34;&#34;&#34;
+    Get the numbered version for the item with the specified ID
+
+    Args:
+        item_id: the item id of the item to fetch
+        version_num: the version number for the item
+
+    Returns: a dictionary object representing the numbered version
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num)
+    response = self.__core.get(resource_path)
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_item_versions"><code class="name flex">
+<span>def <span class="ident">get_item_versions</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get all versions for the item with the specified ID</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: JSON array with all versions for the item</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_versions(self, item_id, allowed_results_per_page=__allowed_results_per_page):
+    &#34;&#34;&#34;
+    Get all versions for the item with the specified ID
+
+    Args:
+        item_id: the item id of the item to fetch
+        allowed_results_per_page: number of results per page
+
+    Returns: JSON array with all versions for the item
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions&#39;
+    versions = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
+    return versions</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_item_workflow_transitions"><code class="name flex">
+<span>def <span class="ident">get_item_workflow_transitions</span></span>(<span>self, item_id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get all valid workflow transitions that can be made with the specified id</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the api id of the item</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: an array of dictionary objects that represent the workflow transitions for the item.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_item_workflow_transitions(self, item_id):
+    &#34;&#34;&#34;
+    Get all valid workflow transitions that can be made with the specified id
+
+    Args:
+        item_id: the api id of the item
+        allowed_results_per_page: number of results per page
+
+    Returns: an array of dictionary objects that represent the workflow transitions for the item.
+
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/workflowtransitionoptions&#39;
+    return self.__get_all(resource_path)</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_items"><code class="name flex">
+<span>def <span class="ident">get_items</span></span>(<span>self, project_id, allowed_results_per_page=20)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return all items in the specified project.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>project_id</code></strong></dt>
 <dd>the project ID</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>Json</code> <code>array</code> of <code>item</code> <code>objects</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: a Json array of item objects</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_items(self, project_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items(self, project_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     This method will return all items in the specified project.
     Args:
         project_id: the project ID
+        allowed_results_per_page: number of results per page
 
     Returns: a Json array of item objects
 
     &#34;&#34;&#34;
     resource_path = &#39;items&#39;
     params = {&#39;project&#39;: project_id}
-    item_data = self.__get_all(resource_path, params=params)
+    item_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return item_data</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_items_downstream_related"><code class="name flex">
-<span>def <span class="ident">get_items_downstream_related</span></span>(<span>self, item_id)</span>
+<span>def <span class="ident">get_items_downstream_related</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all the downstream related items for the item with the specified ID.</p>
+<div class="desc"><p>Returns a list of all the downstream related items for the item with the specified ID.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>the api id of the item to fetch downstream items for</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
 </dl>
-<p>Returns: an array of dictionary objects that represent the downstream related items for the specified item.</p></section>
+<p>Returns: an array of dictionary objects that represent the downstream related items for the specified item.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_items_downstream_related(self, item_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items_downstream_related(self, item_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of all the downstream related items for the item with the specified ID.
 
     Args:
         item_id: the api id of the item to fetch downstream items for
+        allowed_results_per_page: number of results per page
 
     Returns: an array of dictionary objects that represent the downstream related items for the specified item.
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelated&#39;
-    return self.__get_all(resource_path)</code></pre>
+    return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_items_downstream_relationships"><code class="name flex">
-<span>def <span class="ident">get_items_downstream_relationships</span></span>(<span>self, item_id)</span>
+<span>def <span class="ident">get_items_downstream_relationships</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all the downstream relationships for the item with the specified ID.</p>
+<div class="desc"><p>Returns a list of all the downstream relationships for the item with the specified ID.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>the api id of the item</dd>
 </dl>
-<p>Returns: an array of dictionary objects that represent the downstream relationships for the item.</p></section>
+<p>Returns: an array of dictionary objects that represent the downstream relationships for the item.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_items_downstream_relationships(self, item_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items_downstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of all the downstream relationships for the item with the specified ID.
 
@@ -2913,37 +4220,41 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/downstreamrelationships&#39;
-    return self.__get_all(resource_path)</code></pre>
+    return self.__get_all(resource_path, allowed_results_per_page=allowed_results_per_page)</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_items_synceditems"><code class="name flex">
-<span>def <span class="ident">get_items_synceditems</span></span>(<span>self, item_id)</span>
+<span>def <span class="ident">get_items_synceditems</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all synchronized items for the item with the specified ID</p>
+<div class="desc"><p>Get all synchronized items for the item with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>The API id of the item being</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>A</code> <code>list</code> of <code>JSON</code> <code>Objects</code> <code>representing</code> <code>the</code> <code>items</code> <code>that</code> <code>are</code> <code>in</code> <code>the</code> <code>same</code> <code>synchronization</code> <code>group</code> <code>as</code> <code>the</code></dt>
-<dd>&nbsp;</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
 </dl>
-<p>specified item.</p></section>
+<p>Returns: A list of JSON Objects representing the items that are in the same synchronization group as the
+specified item.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_items_synceditems(self, item_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items_synceditems(self, item_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Get all synchronized items for the item with the specified ID
 
     Args:
         item_id: The API id of the item being
+        allowed_results_per_page: Number of results per page
 
     Returns: A list of JSON Objects representing the items that are in the same synchronization group as the
     specified item.
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems&#39;
-    synced_items = self.__get_all(resource_path)
+    synced_items = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return synced_items</code></pre>
 </details>
 </dd>
@@ -2951,7 +4262,7 @@ document keys.</p></section>
 <span>def <span class="ident">get_items_synceditems_status</span></span>(<span>self, item_id, synced_item_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get the sync status for the synced item with the specified ID</p>
+<div class="desc"><p>Get the sync status for the synced item with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
@@ -2959,9 +4270,11 @@ document keys.</p></section>
 <dt><strong><code>synced_item_id</code></strong></dt>
 <dd>the id of the item to check if it is in sync</dd>
 </dl>
-<p>Returns: The response JSON from the API which contains a single field 'inSync' with a boolean value.</p></section>
+<p>Returns: The response JSON from the API which contains a single field 'inSync' with a boolean value.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_items_synceditems_status(self, item_id, synced_item_id):
     &#34;&#34;&#34;
     Get the sync status for the synced item with the specified ID
@@ -2974,50 +4287,90 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/synceditems/&#39; + str(synced_item_id) + &#39;/syncstatus&#39;
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
-<dt id="py_jama_rest_client.client.JamaClient.get_items_upstream_relationships"><code class="name flex">
-<span>def <span class="ident">get_items_upstream_relationships</span></span>(<span>self, item_id)</span>
+<dt id="py_jama_rest_client.client.JamaClient.get_items_upstream_related"><code class="name flex">
+<span>def <span class="ident">get_items_upstream_related</span></span>(<span>self, item_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all the upstream relationships for the item with the specified ID.</p>
+<div class="desc"><p>Returns a list of all the upstream related items for the item with the specified ID.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the api id of the item to fetch upstream items for</dd>
+</dl>
+<p>Returns: an array of dictionary objects that represent the upstream related items for the specified item.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items_upstream_related(self, item_id):
+    &#34;&#34;&#34;
+    Returns a list of all the upstream related items for the item with the specified ID.
+
+    Args:
+        item_id: the api id of the item to fetch upstream items for
+
+    Returns: an array of dictionary objects that represent the upstream related items for the specified item.
+
+     &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelated&#39;
+    return self.__get_all(resource_path)</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_items_upstream_relationships"><code class="name flex">
+<span>def <span class="ident">get_items_upstream_relationships</span></span>(<span>self, item_id, allowed_results_per_page=20)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the upstream relationships for the item with the specified ID.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>the api id of the item</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
 </dl>
-<p>Returns: an array of dictionary objects that represent the upstream relationships for the item.</p></section>
+<p>Returns: an array of dictionary objects that represent the upstream relationships for the item.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_items_upstream_relationships(self, item_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_items_upstream_relationships(self, item_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of all the upstream relationships for the item with the specified ID.
     Args:
         item_id: the api id of the item
+        allowed_results_per_page: number of results per page
 
     Returns: an array of dictionary objects that represent the upstream relationships for the item.
 
     &#34;&#34;&#34;
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/upstreamrelationships&#39;
-    return self.__get_all(resource_path)</code></pre>
+    return self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_pick_list"><code class="name flex">
 <span>def <span class="ident">get_pick_list</span></span>(<span>self, pick_list_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets all a singular picklist</p>
+<div class="desc"><p>Gets all a singular picklist</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>pick_list_id</code></strong></dt>
 <dd>The API id of the pick list to fetch</dd>
 </dl>
-<p>Returns: a dictionary object representing the picklist.</p></section>
+<p>Returns: a dictionary object representing the picklist.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_pick_list(self, pick_list_id):
     &#34;&#34;&#34;
     Gets all a singular picklist
@@ -3029,7 +4382,11 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;picklists/&#39; + str(pick_list_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
@@ -3038,15 +4395,17 @@ document keys.</p></section>
 <span>def <span class="ident">get_pick_list_option</span></span>(<span>self, pick_list_option_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Fetches a single picklist option from the API</p>
+<div class="desc"><p>Fetches a single picklist option from the API</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>pick_list_option_id</code></strong></dt>
 <dd>The API ID of the picklist option to fetch</dd>
 </dl>
-<p>Returns: A dictonary object representing the picklist option.</p></section>
+<p>Returns: A dictonary object representing the picklist option.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_pick_list_option(self, pick_list_option_id):
     &#34;&#34;&#34;
     Fetches a single picklist option from the API
@@ -3057,75 +4416,93 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;picklistoptions/&#39; + str(pick_list_option_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_pick_list_options"><code class="name flex">
-<span>def <span class="ident">get_pick_list_options</span></span>(<span>self, pick_list_id)</span>
+<span>def <span class="ident">get_pick_list_options</span></span>(<span>self, pick_list_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets all all the picklist options for a single picklist</p>
+<div class="desc"><p>Gets all all the picklist options for a single picklist</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>pick_list_id</code></strong></dt>
 <dd>the api id of the picklist to fetch options for.</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
 </dl>
-<p>Returns: an array of dictionary objects that represent the picklist options.</p></section>
+<p>Returns: an array of dictionary objects that represent the picklist options.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_pick_list_options(self, pick_list_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_pick_list_options(self, pick_list_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Gets all all the picklist options for a single picklist
     Args:
         pick_list_id: the api id of the picklist to fetch options for.
+        allowed_results_per_page: number of results per page
 
     Returns: an array of dictionary objects that represent the picklist options.
 
     &#34;&#34;&#34;
     resource_path = &#39;picklists/&#39; + str(pick_list_id) + &#39;/options&#39;
-    pick_list_options = self.__get_all(resource_path)
+    pick_list_options = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return pick_list_options</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_pick_lists"><code class="name flex">
-<span>def <span class="ident">get_pick_lists</span></span>(<span>self)</span>
+<span>def <span class="ident">get_pick_lists</span></span>(<span>self, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all the pick lists</p>
+<div class="desc"><p>Returns a list of all the pick lists</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>an</code> <code>array</code> of <code>dictionary</code> <code>objects</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: an array of dictionary objects</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_pick_lists(self):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_pick_lists(self, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of all the pick lists
+
+    Args:
+        allowed_results_per_page: number of results per page
 
     Returns: an array of dictionary objects
 
     &#34;&#34;&#34;
     resource_path = &#39;picklists/&#39;
-    pick_lists = self.__get_all(resource_path)
+    pick_lists = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return pick_lists</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_projects"><code class="name flex">
-<span>def <span class="ident">get_projects</span></span>(<span>self)</span>
+<span>def <span class="ident">get_projects</span></span>(<span>self, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all projects as JSON object
-:return: JSON Array of Item Objects.</p></section>
+<div class="desc"><p>This method will return all projects as JSON object
+:return: JSON Array of Item Objects.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_projects(self):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_projects(self, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;This method will return all projects as JSON object
     :return: JSON Array of Item Objects.
     &#34;&#34;&#34;
     resource_path = &#39;projects&#39;
-    project_data = self.__get_all(resource_path)
+    project_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return project_data</code></pre>
 </details>
 </dd>
@@ -3133,16 +4510,17 @@ document keys.</p></section>
 <span>def <span class="ident">get_relationship</span></span>(<span>self, relationship_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a specific relationship object of a specified relationship ID</p>
+<div class="desc"><p>Returns a specific relationship object of a specified relationship ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>relationship_id</code></strong></dt>
 <dd>the api project id of a relationship</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>dictionary</code> <code>object</code> <code>that</code> <code>represents</code> <code>a</code> <code>relationship</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: a dictionary object that represents a relationship</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_relationship(self, relationship_id):
     &#34;&#34;&#34;
     Returns a specific relationship object of a specified relationship ID
@@ -3154,25 +4532,97 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;relationships/&#39; + str(relationship_id)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_relationship_rule_set"><code class="name flex">
+<span>def <span class="ident">get_relationship_rule_set</span></span>(<span>self, id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return the relationship rule sets by id.</p>
+<p>Returns: A dictionary object representing a rule set and its associated rules</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_relationship_rule_set(self, id):
+    &#34;&#34;&#34;
+    This method will return the relationship rule sets by id.
+
+    Returns: A dictionary object representing a rule set and its associated rules
+
+    &#34;&#34;&#34;
+    resource_path = &#39;relationshiprulesets/&#39; + str(id)
     response = self.__core.get(resource_path)
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_relationship_rule_set_projects"><code class="name flex">
+<span>def <span class="ident">get_relationship_rule_set_projects</span></span>(<span>self, id)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return the projects that have a given relationship rule set defined.</p>
+<p>Returns: An array of the dictionary objects representing the projects with a given rule set assigned</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_relationship_rule_set_projects(self, id):
+    &#34;&#34;&#34;
+    This method will return the projects that have a given relationship rule set defined.
+
+    Returns: An array of the dictionary objects representing the projects with a given rule set assigned
+
+    &#34;&#34;&#34;
+    resource_path = &#39;relationshiprulesets/&#39; + str(id) + &#39;/projects&#39;
+    projects = self.__get_all(resource_path)
+    return projects</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_relationship_rule_sets"><code class="name flex">
+<span>def <span class="ident">get_relationship_rule_sets</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This method will return all relationship rule sets across all projects of the Jama Connect instance.</p>
+<p>Returns: An array of dictionary objects representing a rule set and its associated rules</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_relationship_rule_sets(self):
+    &#34;&#34;&#34;
+    This method will return all relationship rule sets across all projects of the Jama Connect instance.
+
+    Returns: An array of dictionary objects representing a rule set and its associated rules
+
+    &#34;&#34;&#34;
+    resource_path = &#39;relationshiprulesets/&#39;
+    rule_sets = self.__get_all(resource_path)
+    return rule_sets</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_relationship_type"><code class="name flex">
 <span>def <span class="ident">get_relationship_type</span></span>(<span>self, relationship_type_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets relationship type information for a specific relationship type id.</p>
+<div class="desc"><p>Gets relationship type information for a specific relationship type id.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>relationship_type_id</code></strong></dt>
 <dd>The api id of the item type to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>JSON</code> <code>object</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: JSON object</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_relationship_type(self, relationship_type_id):
     &#34;&#34;&#34;
     Gets relationship type information for a specific relationship type id.
@@ -3184,84 +4634,105 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;relationshiptypes/&#39; + str(relationship_type_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_relationship_types"><code class="name flex">
-<span>def <span class="ident">get_relationship_types</span></span>(<span>self)</span>
+<span>def <span class="ident">get_relationship_types</span></span>(<span>self, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all relationship types of the across all projects of the Jama Connect instance.</p>
+<div class="desc"><p>This method will return all relationship types of the across all projects of the Jama Connect instance.</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>An</code> <code>array</code> of <code>dictionary</code> <code>objects</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
+</dl>
+<p>Returns: An array of dictionary objects</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_relationship_types(self):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_relationship_types(self, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     This method will return all relationship types of the across all projects of the Jama Connect instance.
+
+    Args:
+        allowed_results_per_page: Number of results per page
 
     Returns: An array of dictionary objects
 
     &#34;&#34;&#34;
     resource_path = &#39;relationshiptypes/&#39;
-    item_types = self.__get_all(resource_path)
+    item_types = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return item_types</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_relationships"><code class="name flex">
-<span>def <span class="ident">get_relationships</span></span>(<span>self, project_id)</span>
+<span>def <span class="ident">get_relationships</span></span>(<span>self, project_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns a list of all relationships of a specified project</p>
+<div class="desc"><p>Returns a list of all relationships of a specified project</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>project_id</code></strong></dt>
 <dd>the api project id of a project</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>list</code> of <code>dictionary</code> <code>objects</code> <code>that</code> <code>represents</code> <code>a</code> <code>relationships</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>number of results per page</dd>
+</dl>
+<p>Returns: a list of dictionary objects that represents a relationships</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_relationships(self, project_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_relationships(self, project_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Returns a list of all relationships of a specified project
 
     Args:
         project_id: the api project id of a project
+        allowed_results_per_page: number of results per page
 
     Returns: a list of dictionary objects that represents a relationships
 
     &#34;&#34;&#34;
     resource_path = &#39;relationships&#39;
     params = {&#39;project&#39;: project_id}
-    relationship_data = self.__get_all(resource_path, params=params)
+    relationship_data = self.__get_all(resource_path, params=params,
+                                       allowed_results_per_page=allowed_results_per_page)
     return relationship_data</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_tagged_items"><code class="name flex">
-<span>def <span class="ident">get_tagged_items</span></span>(<span>self, tag_id)</span>
+<span>def <span class="ident">get_tagged_items</span></span>(<span>self, tag_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all items tagged with the specified ID</p>
+<div class="desc"><p>Get all items tagged with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>tag_id</code></strong></dt>
 <dd>The ID of the tag to fetch the results for.</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A List of items that match the tag.</p></section>
+<p>A List of items that match the tag.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_tagged_items(self, tag_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_tagged_items(self, tag_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Get all items tagged with the specified ID
 
     Args:
         tag_id: The ID of the tag to fetch the results for.
+        allowed_results_per_page: Number of results per page
 
     Returns:
         A List of items that match the tag.
@@ -3269,35 +4740,40 @@ document keys.</p></section>
     &#34;&#34;&#34;
     resource_path = &#39;tags/&#39; + str(tag_id) + &#39;/items&#39;
     params = None
-    tag_results = self.__get_all(resource_path, params=params)
+    tag_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return tag_results</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_tags"><code class="name flex">
-<span>def <span class="ident">get_tags</span></span>(<span>self, project)</span>
+<span>def <span class="ident">get_tags</span></span>(<span>self, project, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get all tags for the project with the specified id</p>
+<div class="desc"><p>Get all tags for the project with the specified id</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>project</code></strong></dt>
 <dd>The API ID of the project to fetch tags for.</dd>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
 </dl>
-<p>Returns: A Json Array that contains all the tag data for the specified project.</p></section>
+<p>Returns: A Json Array that contains all the tag data for the specified project.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_tags(self, project):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_tags(self, project, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Get all tags for the project with the specified id
     Args:
         project: The API ID of the project to fetch tags for.
+        allowed_results_per_page: Number of results per page
 
     Returns: A Json Array that contains all the tag data for the specified project.
 
     &#34;&#34;&#34;
     resource_path = &#39;tags&#39;
     params = {&#39;project&#39;: project}
-    tag_data = self.__get_all(resource_path, params=params)
+    tag_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
     return tag_data</code></pre>
 </details>
 </dd>
@@ -3305,16 +4781,17 @@ document keys.</p></section>
 <span>def <span class="ident">get_test_cycle</span></span>(<span>self, test_cycle_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return JSON data about the test cycle specified by the test cycle id.</p>
+<div class="desc"><p>This method will return JSON data about the test cycle specified by the test cycle id.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>test_cycle_id</code></strong></dt>
 <dd>the api id of the test cycle to fetch</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>a</code> <code>dictionary</code> <code>object</code> <code>that</code> <code>represents</code> <code>the</code> <code>test</code> <code>cycle</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: a dictionary object that represents the test cycle</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_test_cycle(self, test_cycle_id):
     &#34;&#34;&#34;
     This method will return JSON data about the test cycle specified by the test cycle id.
@@ -3326,25 +4803,31 @@ document keys.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;testcycles/&#39; + str(test_cycle_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_testruns"><code class="name flex">
-<span>def <span class="ident">get_testruns</span></span>(<span>self, test_cycle_id)</span>
+<span>def <span class="ident">get_testruns</span></span>(<span>self, test_cycle_id, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will return all test runs associated with the specified test cycle.
+<div class="desc"><p>This method will return all test runs associated with the specified test cycle.
 Test runs will be returned
-as a list of json objects.</p></section>
+as a list of json objects.</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_testruns(self, test_cycle_id):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_testruns(self, test_cycle_id, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;This method will return all test runs associated with the specified test cycle.  Test runs will be returned
     as a list of json objects.&#34;&#34;&#34;
     resource_path = &#39;testcycles/&#39; + str(test_cycle_id) + &#39;/testruns&#39;
-    testrun_data = self.__get_all(resource_path)
+    testrun_data = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return testrun_data</code></pre>
 </details>
 </dd>
@@ -3352,16 +4835,17 @@ as a list of json objects.</p></section>
 <span>def <span class="ident">get_user</span></span>(<span>self, user_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets a single speificed user</p>
+<div class="desc"><p>Gets a single speificed user</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>user_id</code></strong></dt>
 <dd>user api ID</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>JSON</code> <code>obect</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: JSON obect</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get_user(self, user_id):
     &#34;&#34;&#34;
     Gets a single speificed user
@@ -3373,56 +4857,101 @@ as a list of json objects.</p></section>
 
     &#34;&#34;&#34;
     resource_path = &#39;users/&#39; + str(user_id)
-    response = self.__core.get(resource_path)
+    try:
+        response = self.__core.get(resource_path)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.get_users"><code class="name flex">
-<span>def <span class="ident">get_users</span></span>(<span>self)</span>
+<span>def <span class="ident">get_users</span></span>(<span>self, allowed_results_per_page=20)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Gets a list of all active users visible to the current user</p>
+<div class="desc"><p>Gets a list of all active users visible to the current user</p>
+<h2 id="args">Args</h2>
 <dl>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>JSON</code> <code>array</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<dt><strong><code>allowed_results_per_page</code></strong></dt>
+<dd>Number of results per page</dd>
+</dl>
+<p>Returns: JSON array</p></div>
 <details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def get_users(self):
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_users(self, allowed_results_per_page=__allowed_results_per_page):
     &#34;&#34;&#34;
     Gets a list of all active users visible to the current user
+
+    Args:
+        allowed_results_per_page: Number of results per page
 
     Returns: JSON array
 
     &#34;&#34;&#34;
     resource_path = &#39;users/&#39;
-    users = self.__get_all(resource_path)
+    users = self.__get_all(resource_path,  allowed_results_per_page=allowed_results_per_page)
     return users</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.get_versioned_item"><code class="name flex">
+<span>def <span class="ident">get_versioned_item</span></span>(<span>self, item_id, version_num)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the snapshot of the item at the specified version</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>item_id</code></strong></dt>
+<dd>the item id of the item to fetch</dd>
+<dt><strong><code>version_num</code></strong></dt>
+<dd>the version number for the item</dd>
+</dl>
+<p>Returns: a dictionary object representing the versioned item</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_versioned_item(self, item_id, version_num):
+    &#34;&#34;&#34;
+    Get the snapshot of the item at the specified version
+
+    Args:
+        item_id: the item id of the item to fetch
+        version_num: the version number for the item
+
+    Returns: a dictionary object representing the versioned item
+    &#34;&#34;&#34;
+    resource_path = &#39;items/&#39; + str(item_id) + &#39;/versions/&#39; + str(version_num) + &#39;/versioneditem&#39;
+    response = self.__core.get(resource_path)
+    JamaClient.__handle_response_status(response)
+    return response.json()[&#39;data&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.patch_item"><code class="name flex">
 <span>def <span class="ident">patch_item</span></span>(<span>self, item_id, patches)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will patch an item.</p>
+<div class="desc"><p>This method will patch an item.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>the API ID of the item that is to be patched</dd>
 <dt><strong><code>patches</code></strong></dt>
 <dd>An array of dicts, that represent patch operations each dict should have the following entries</dd>
-<dt>[</dt>
-<dt>{</dt>
-<dt>"op": string,</dt>
-<dt>"path": string,</dt>
-<dt>"value":</dt>
-<dt>}</dt>
-<dt>]</dt>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>The</code> <code>response</code> <code>status</code> <code>code</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>[
+{
+"op": string,
+"path": string,
+"value": {}
+}
+]
+Returns: The response status code</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def patch_item(self, item_id, patches):
     &#34;&#34;&#34;
     This method will patch an item.
@@ -3447,7 +4976,11 @@ as a list of json objects.</p></section>
     data = json.dumps(patches)
 
     # Make the API Call
-    response = self.__core.patch(resource_path, data=data, headers=headers)
+    try:
+        response = self.__core.patch(resource_path, data=data, headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
 
     # validate response
     JamaClient.__handle_response_status(response)
@@ -3458,16 +4991,18 @@ as a list of json objects.</p></section>
 <span>def <span class="ident">post_item</span></span>(<span>self, project, item_type_id, child_item_type_id, location, fields, global_id=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will post a new item to Jama Connect.
+<div class="desc"><p>This method will post a new item to Jama Connect.
 :param global_id: optional param to post the item with a custom global id
 :param project integer representing the project to which this item is to be posted
 :param item_type_id integer ID of an Item Type.
 :param child_item_type_id integer ID of an Item Type.
 :param location dictionary with integer ID of the parent item or project.
 :param fields dictionary item field data.
-:return integer ID of the successfully posted item or None if there was an error.</p></section>
+:return integer ID of the successfully posted item or None if there was an error.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_item(self, project, item_type_id, child_item_type_id, location, fields, global_id=None):
     &#34;&#34;&#34; This method will post a new item to Jama Connect.
     :param global_id: optional param to post the item with a custom global id
@@ -3496,7 +5031,11 @@ as a list of json objects.</p></section>
         params[&#39;setGlobalIdManually&#39;] = True
 
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers, params=params)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
@@ -3505,12 +5044,14 @@ as a list of json objects.</p></section>
 <span>def <span class="ident">post_item_attachment</span></span>(<span>self, item_id, attachment_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Add an existing attachment to the item with the specified ID
+<div class="desc"><p>Add an existing attachment to the item with the specified ID
 :param item_id: this is the ID of the item
 :param attachment_id: The ID of the attachment
-:return: 201 if successful / the response status of the post operation</p></section>
+:return: 201 if successful / the response status of the post operation</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_item_attachment(self, item_id, attachment_id):
     &#34;&#34;&#34;
     Add an existing attachment to the item with the specified ID
@@ -3521,16 +5062,20 @@ as a list of json objects.</p></section>
     body = {&#34;attachment&#34;: attachment_id}
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/attachments&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.status_code</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.post_item_sync"><code class="name flex">
-<span>def <span class="ident">post_item_sync</span></span>(<span>self, source_item, pool_item)</span>
+<span>def <span class="ident">post_item_sync</span></span>(<span>self, source_item: int, pool_item: int)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>add an item to an existing pool of global ids</p>
+<div class="desc"><p>add an item to an existing pool of global ids</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>source_item</code></strong></dt>
@@ -3539,9 +5084,11 @@ pool_item.</dd>
 <dt><strong><code>pool_item</code></strong></dt>
 <dd>integer API ID of the item in the target global ID pool.</dd>
 </dl>
-<p>Returns: the integer ID of the modified source item.</p></section>
+<p>Returns: the integer ID of the modified source item.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_item_sync(self, source_item: int, pool_item: int):
     &#34;&#34;&#34;
     add an item to an existing pool of global ids
@@ -3558,7 +5105,11 @@ pool_item.</dd>
 
     resource_path = &#39;items/&#39; + str(pool_item) + &#39;/synceditems&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
@@ -3567,18 +5118,19 @@ pool_item.</dd>
 <span>def <span class="ident">post_item_tag</span></span>(<span>self, item_id, tag_id)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Add an existing tag to the item with the specified ID</p>
+<div class="desc"><p>Add an existing tag to the item with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
 <dd>The API ID of the item to add a tag.</dd>
 <dt><strong><code>tag_id</code></strong></dt>
 <dd>The API ID of the tag to add to the item.</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>201</code> <code>if</code> <code>successful</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: 201 if successful</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_item_tag(self, item_id, tag_id):
     &#34;&#34;&#34;
     Add an existing tag to the item with the specified ID
@@ -3594,7 +5146,11 @@ pool_item.</dd>
     }
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/tags&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.status_code</code></pre>
 </details>
@@ -3603,14 +5159,16 @@ pool_item.</dd>
 <span>def <span class="ident">post_project_attachment</span></span>(<span>self, project_id, name, description)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This Method will make a new attachment object in the specified project
+<div class="desc"><p>This Method will make a new attachment object in the specified project
 :param project_id: The integer project ID to create the attachment in.
 :param name:
 The name of the attachment
 :param description: The description of the attachment
-:return: Returns the ID of the newly created attachment object.</p></section>
+:return: Returns the ID of the newly created attachment object.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_project_attachment(self, project_id, name, description):
     &#34;&#34;&#34;
     This Method will make a new attachment object in the specified project
@@ -3628,16 +5186,20 @@ The name of the attachment
 
     resource_path = &#39;projects/&#39; + str(project_id) + &#39;/attachments&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.post_relationship"><code class="name flex">
-<span>def <span class="ident">post_relationship</span></span>(<span>self, from_item, to_item, relationship_type=None)</span>
+<span>def <span class="ident">post_relationship</span></span>(<span>self, from_item: int, to_item: int, relationship_type=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><h2 id="args">Args</h2>
+<div class="desc"><h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>from_item</code></strong></dt>
 <dd>integer API id of the source item</dd>
@@ -3646,9 +5208,11 @@ The name of the attachment
 <dt><strong><code>relationship_type</code></strong></dt>
 <dd>Optional integer API id of the relationship type to create</dd>
 </dl>
-<p>Returns: The integer ID of the newly created relationship.</p></section>
+<p>Returns: The integer ID of the newly created relationship.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_relationship(self, from_item: int, to_item: int, relationship_type=None):
     &#34;&#34;&#34;
 
@@ -3668,16 +5232,20 @@ The name of the attachment
         body[&#39;relationshipType&#39;] = relationship_type
     resource_path = &#39;relationships/&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
 </dd>
 <dt id="py_jama_rest_client.client.JamaClient.post_tag"><code class="name flex">
-<span>def <span class="ident">post_tag</span></span>(<span>self, name, project)</span>
+<span>def <span class="ident">post_tag</span></span>(<span>self, name: str, project: int)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Create a new tag in the project with the specified ID</p>
+<div class="desc"><p>Create a new tag in the project with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -3685,9 +5253,11 @@ The name of the attachment
 <dt><strong><code>project</code></strong></dt>
 <dd>The project to create the new tag in</dd>
 </dl>
-<p>Returns: The integer API ID fr the newly created Tag.</p></section>
+<p>Returns: The integer API ID fr the newly created Tag.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_tag(self, name: str, project: int):
     &#34;&#34;&#34;
     Create a new tag in the project with the specified ID
@@ -3703,7 +5273,11 @@ The name of the attachment
         &#39;project&#39;: project
     }
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
@@ -3712,7 +5286,7 @@ The name of the attachment
 <span>def <span class="ident">post_testplans_testcycles</span></span>(<span>self, testplan_id, testcycle_name, start_date, end_date, testgroups_to_include=None, testrun_status_to_include=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will create a new Test Cycle.</p>
+<div class="desc"><p>This method will create a new Test Cycle.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>testplan_id</code></strong> :&ensp;<code>int</code></dt>
@@ -3723,17 +5297,19 @@ The name of the attachment
 <dd>Start date in 'yyyy-mm-dd' Format</dd>
 <dt><strong><code>end_date</code></strong> :&ensp;<code>str</code></dt>
 <dd>End date in 'yyyy-mm-dd' Format</dd>
-<dt><strong><code>testgroups_to_include</code></strong> :&ensp;<code>int</code>[]</dt>
+<dt><strong><code>testgroups_to_include</code></strong> :&ensp;<code>int[]</code></dt>
 <dd>This array of integers specify the test groups to be included.</dd>
-<dt><strong><code>testrun_status_to_include</code></strong> :&ensp;<code>str</code>[]</dt>
+<dt><strong><code>testrun_status_to_include</code></strong> :&ensp;<code>str[]</code></dt>
 <dd>Only valid after generating the first Test Cycle, you may choose to only
 generate Test Runs that were a specified status in the previous cycle. Do not specify anything to
 include all statuses</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>(int): Returns the integer id for the newly created testcycle, or None if something went terribly wrong.</p></section>
+<p>(int): Returns the integer id for the newly created testcycle, or None if something went terribly wrong.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_testplans_testcycles(self, testplan_id, testcycle_name, start_date, end_date, testgroups_to_include=None,
                               testrun_status_to_include=None):
     &#34;&#34;&#34;
@@ -3770,7 +5346,11 @@ include all statuses</dd>
     }
 
     # Make the API Call
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
 
     # Validate response
     JamaClient.__handle_response_status(response)
@@ -3781,7 +5361,7 @@ include all statuses</dd>
 <span>def <span class="ident">post_user</span></span>(<span>self, username, password, first_name, last_name, email, license_type, phone=None, title=None, location=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Creates a new user</p>
+<div class="desc"><p>Creates a new user</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>username</code></strong></dt>
@@ -3802,11 +5382,12 @@ include all statuses</dd>
 <dd>str - optional</dd>
 <dt><strong><code>licenseType</code></strong></dt>
 <dd>enum [ NAMED, FLOATING, STAKEHOLDER, FLOATING_COLLABORATOR, RESERVED_COLLABORATOR, FLOATING_REVIEWER, RESERVED_REVIEWER, NAMED_REVIEWER, TEST_RUNNER, EXPIRING_TRIAL, INACTIVE ]</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>int</code> of <code>newly</code> <code>created</code> <code>user</code> <code>api</code> <code>ID</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: int of newly created user api ID</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post_user(self, username, password, first_name, last_name, email, license_type, phone=None, title=None,
               location=None):
     &#34;&#34;&#34;
@@ -3840,7 +5421,11 @@ include all statuses</dd>
     }
     resource_path = &#39;users/&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.post(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     JamaClient.__handle_response_status(response)
     return response.json()[&#39;meta&#39;][&#39;id&#39;]</code></pre>
 </details>
@@ -3849,12 +5434,14 @@ include all statuses</dd>
 <span>def <span class="ident">put_attachments_file</span></span>(<span>self, attachment_id, file_path)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Upload a file to a jama attachment
+<div class="desc"><p>Upload a file to a jama attachment
 :param attachment_id: the integer ID of the attachment item to which we are uploading the file
 :param file_path: the file path of the file to be uploaded
-:return: returns the status code of the call</p></section>
+:return: returns the status code of the call</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_attachments_file(self, attachment_id, file_path):
     &#34;&#34;&#34;
     Upload a file to a jama attachment
@@ -3865,8 +5452,11 @@ include all statuses</dd>
     resource_path = &#39;attachments/&#39; + str(attachment_id) + &#39;/file&#39;
     with open(file_path, &#39;rb&#39;) as f:
         files = {&#39;file&#39;: f}
-        response = self.__core.put(resource_path, files=files)
-
+        try:
+            response = self.__core.put(resource_path, files=files)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
     self.__handle_response_status(response)
     return response.status_code</code></pre>
 </details>
@@ -3875,7 +5465,7 @@ include all statuses</dd>
 <span>def <span class="ident">put_item</span></span>(<span>self, project, item_id, item_type_id, child_item_type_id, location, fields)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method wil
+<div class="desc"><p>This method wil
 PUT a new item to Jama Connect.
 :param project integer representing the project to which this item is to be posted
 :param item_id integer representing the item which is to be updated
@@ -3884,9 +5474,11 @@ PUT a new item to Jama Connect.
 :param location dictionary
 with a key of 'item' or 'project' and an value with the ID of the parent
 :param fields dictionary item field data.
-:return integer ID of the successfully posted item or None if there was an error.</p></section>
+:return integer ID of the successfully posted item or None if there was an error.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_item(self, project, item_id, item_type_id, child_item_type_id, location, fields):
     &#34;&#34;&#34; This method wil
      PUT a new item to Jama Connect.
@@ -3909,7 +5501,11 @@ with a key of 'item' or 'project' and an value with the ID of the parent
     }
     resource_path = &#39;items/&#39; + str(item_id)
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return self.__handle_response_status(response)</code></pre>
 </details>
 </dd>
@@ -3917,7 +5513,7 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <span>def <span class="ident">put_item_lock</span></span>(<span>self, item_id, locked)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Update the locked state of the item with the specified ID</p>
+<div class="desc"><p>Update the locked state of the item with the specified ID</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>item_id</code></strong></dt>
@@ -3926,9 +5522,11 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <dd>boolean lock state to apply to this item</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>response status 200</p></section>
+<p>response status 200</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_item_lock(self, item_id, locked):
     &#34;&#34;&#34;
     Update the locked state of the item with the specified ID
@@ -3945,7 +5543,11 @@ with a key of 'item' or 'project' and an value with the ID of the parent
     }
     resource_path = &#39;items/&#39; + str(item_id) + &#39;/lock&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return self.__handle_response_status(response)</code></pre>
 </details>
 </dd>
@@ -3953,14 +5555,20 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <span>def <span class="ident">put_test_run</span></span>(<span>self, test_run_id, data=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will post a test run to Jama through the API</p></section>
+<div class="desc"><p>This method will post a test run to Jama through the API</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_test_run(self, test_run_id, data=None):
     &#34;&#34;&#34; This method will post a test run to Jama through the API&#34;&#34;&#34;
     resource_path = &#39;testruns/&#39; + str(test_run_id)
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.put(resource_path, data=data, headers=headers)
+    try:
+        response = self.__core.put(resource_path, data=data, headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return self.__handle_response_status(response)</code></pre>
 </details>
 </dd>
@@ -3968,7 +5576,7 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <span>def <span class="ident">put_user</span></span>(<span>self, user_id, username, password, first_name, last_name, email, phone=None, title=None, location=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>updates an existing user</p>
+<div class="desc"><p>updates an existing user</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>username</code></strong></dt>
@@ -3987,11 +5595,12 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <dd>str - optional</dd>
 <dt><strong><code>location</code></strong></dt>
 <dd>str - optional</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>api</code> <code>status</code> <code>code</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: api status code</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_user(self, user_id, username, password, first_name, last_name, email, phone=None, title=None,
              location=None):
     &#34;&#34;&#34;
@@ -4023,7 +5632,12 @@ with a key of 'item' or 'project' and an value with the ID of the parent
     }
     resource_path = &#39;users/&#39; + str(user_id)
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
+        raise APIException
     return self.__handle_response_status(response)</code></pre>
 </details>
 </dd>
@@ -4031,16 +5645,17 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <span>def <span class="ident">put_user_active</span></span>(<span>self, user_id, is_active)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>updates an existing users active status</p>
+<div class="desc"><p>updates an existing users active status</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>is_active</code></strong></dt>
 <dd>boolean</dd>
-<dt><strong><code>Returns</code></strong> :&ensp;<code>api</code> <code>status</code> <code>code</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+</dl>
+<p>Returns: api status code</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put_user_active(self, user_id, is_active):
     &#34;&#34;&#34;
     updates an existing users active status
@@ -4056,73 +5671,90 @@ with a key of 'item' or 'project' and an value with the ID of the parent
     }
     resource_path = &#39;users/&#39; + str(user_id) + &#39;/active&#39;
     headers = {&#39;content-type&#39;: &#39;application/json&#39;}
-    response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    try:
+        response = self.__core.put(resource_path, data=json.dumps(body), headers=headers)
+    except CoreException as err:
+        py_jama_rest_client_logger.error(err)
+        raise APIException(str(err))
     return self.__handle_response_status(response)</code></pre>
+</details>
+</dd>
+<dt id="py_jama_rest_client.client.JamaClient.set_allowed_results_per_page"><code class="name flex">
+<span>def <span class="ident">set_allowed_results_per_page</span></span>(<span>self, allowed_results_per_page)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_allowed_results_per_page(self, allowed_results_per_page):
+    self.__allowed_results_per_page = allowed_results_per_page</code></pre>
 </details>
 </dd>
 </dl>
 </dd>
 <dt id="py_jama_rest_client.client.ResourceNotFoundException"><code class="flex name class">
 <span>class <span class="ident">ResourceNotFoundException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is raised whenever the api returns a 404 not found response.</p></section>
+<div class="desc"><p>This exception is raised whenever the api returns a 404 not found response.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class ResourceNotFoundException(APIException):
     &#34;&#34;&#34;This exception is raised whenever the api returns a 404 not found response.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 <dt id="py_jama_rest_client.client.TooManyRequestsException"><code class="flex name class">
 <span>class <span class="ident">TooManyRequestsException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is thrown whenever the api returns a 429 too many requests response.</p></section>
+<div class="desc"><p>This exception is thrown whenever the api returns a 429 too many requests response.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class TooManyRequestsException(APIException):
     &#34;&#34;&#34;This exception is thrown whenever the api returns a 429 too many requests response.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 <dt id="py_jama_rest_client.client.UnauthorizedException"><code class="flex name class">
 <span>class <span class="ident">UnauthorizedException</span></span>
-<span>(</span><span><small>ancestors:</small> <a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a>, builtins.Exception, builtins.BaseException)</span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This exception is thrown whenever the api returns a 401 unauthorized response.</p></section>
+<div class="desc"><p>This exception is thrown whenever the api returns a 401 unauthorized response.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class UnauthorizedException(APIException):
     &#34;&#34;&#34;This exception is thrown whenever the api returns a 401 unauthorized response.&#34;&#34;&#34;
     pass</code></pre>
 </details>
-<h3>Inherited members</h3>
+<h3>Ancestors</h3>
 <ul class="hlist">
-<li><code><b><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></b></code>:
-<ul class="hlist">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
-</li>
+<li><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
 </ul>
 </dd>
 </dl>
@@ -4146,9 +5778,6 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 </li>
 <li>
 <h4><code><a title="py_jama_rest_client.client.APIException" href="#py_jama_rest_client.client.APIException">APIException</a></code></h4>
-<ul class="">
-<li><code><a title="py_jama_rest_client.client.APIException.__init__" href="#py_jama_rest_client.client.APIException.__init__">__init__</a></code></li>
-</ul>
 </li>
 <li>
 <h4><code><a title="py_jama_rest_client.client.APIServerException" href="#py_jama_rest_client.client.APIServerException">APIServerException</a></code></h4>
@@ -4159,11 +5788,15 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <li>
 <h4><code><a title="py_jama_rest_client.client.JamaClient" href="#py_jama_rest_client.client.JamaClient">JamaClient</a></code></h4>
 <ul class="">
-<li><code><a title="py_jama_rest_client.client.JamaClient.__init__" href="#py_jama_rest_client.client.JamaClient.__init__">__init__</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.delete_item" href="#py_jama_rest_client.client.JamaClient.delete_item">delete_item</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.delete_relationships" href="#py_jama_rest_client.client.JamaClient.delete_relationships">delete_relationships</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_abstract_item" href="#py_jama_rest_client.client.JamaClient.get_abstract_item">get_abstract_item</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_abstract_item_versions" href="#py_jama_rest_client.client.JamaClient.get_abstract_item_versions">get_abstract_item_versions</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_abstract_items" href="#py_jama_rest_client.client.JamaClient.get_abstract_items">get_abstract_items</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_abstract_items_from_doc_key" href="#py_jama_rest_client.client.JamaClient.get_abstract_items_from_doc_key">get_abstract_items_from_doc_key</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_abstract_versioned_item" href="#py_jama_rest_client.client.JamaClient.get_abstract_versioned_item">get_abstract_versioned_item</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_abtract_item_version" href="#py_jama_rest_client.client.JamaClient.get_abtract_item_version">get_abtract_item_version</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_allowed_results_per_page" href="#py_jama_rest_client.client.JamaClient.get_allowed_results_per_page">get_allowed_results_per_page</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_attachment" href="#py_jama_rest_client.client.JamaClient.get_attachment">get_attachment</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_available_endpoints" href="#py_jama_rest_client.client.JamaClient.get_available_endpoints">get_available_endpoints</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_baseline" href="#py_jama_rest_client.client.JamaClient.get_baseline">get_baseline</a></code></li>
@@ -4171,16 +5804,23 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_baselines_versioneditems" href="#py_jama_rest_client.client.JamaClient.get_baselines_versioneditems">get_baselines_versioneditems</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_current_user" href="#py_jama_rest_client.client.JamaClient.get_current_user">get_current_user</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_filter_results" href="#py_jama_rest_client.client.JamaClient.get_filter_results">get_filter_results</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_filter_results_count" href="#py_jama_rest_client.client.JamaClient.get_filter_results_count">get_filter_results_count</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_item" href="#py_jama_rest_client.client.JamaClient.get_item">get_item</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_item_children" href="#py_jama_rest_client.client.JamaClient.get_item_children">get_item_children</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_item_links" href="#py_jama_rest_client.client.JamaClient.get_item_links">get_item_links</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_item_lock" href="#py_jama_rest_client.client.JamaClient.get_item_lock">get_item_lock</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_item_tags" href="#py_jama_rest_client.client.JamaClient.get_item_tags">get_item_tags</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_item_type" href="#py_jama_rest_client.client.JamaClient.get_item_type">get_item_type</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_item_types" href="#py_jama_rest_client.client.JamaClient.get_item_types">get_item_types</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_item_version" href="#py_jama_rest_client.client.JamaClient.get_item_version">get_item_version</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_item_versions" href="#py_jama_rest_client.client.JamaClient.get_item_versions">get_item_versions</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_item_workflow_transitions" href="#py_jama_rest_client.client.JamaClient.get_item_workflow_transitions">get_item_workflow_transitions</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items" href="#py_jama_rest_client.client.JamaClient.get_items">get_items</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items_downstream_related" href="#py_jama_rest_client.client.JamaClient.get_items_downstream_related">get_items_downstream_related</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items_downstream_relationships" href="#py_jama_rest_client.client.JamaClient.get_items_downstream_relationships">get_items_downstream_relationships</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items_synceditems" href="#py_jama_rest_client.client.JamaClient.get_items_synceditems">get_items_synceditems</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items_synceditems_status" href="#py_jama_rest_client.client.JamaClient.get_items_synceditems_status">get_items_synceditems_status</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_items_upstream_related" href="#py_jama_rest_client.client.JamaClient.get_items_upstream_related">get_items_upstream_related</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_items_upstream_relationships" href="#py_jama_rest_client.client.JamaClient.get_items_upstream_relationships">get_items_upstream_relationships</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_pick_list" href="#py_jama_rest_client.client.JamaClient.get_pick_list">get_pick_list</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_pick_list_option" href="#py_jama_rest_client.client.JamaClient.get_pick_list_option">get_pick_list_option</a></code></li>
@@ -4188,6 +5828,9 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_pick_lists" href="#py_jama_rest_client.client.JamaClient.get_pick_lists">get_pick_lists</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_projects" href="#py_jama_rest_client.client.JamaClient.get_projects">get_projects</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship" href="#py_jama_rest_client.client.JamaClient.get_relationship">get_relationship</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship_rule_set" href="#py_jama_rest_client.client.JamaClient.get_relationship_rule_set">get_relationship_rule_set</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship_rule_set_projects" href="#py_jama_rest_client.client.JamaClient.get_relationship_rule_set_projects">get_relationship_rule_set_projects</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship_rule_sets" href="#py_jama_rest_client.client.JamaClient.get_relationship_rule_sets">get_relationship_rule_sets</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship_type" href="#py_jama_rest_client.client.JamaClient.get_relationship_type">get_relationship_type</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_relationship_types" href="#py_jama_rest_client.client.JamaClient.get_relationship_types">get_relationship_types</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_relationships" href="#py_jama_rest_client.client.JamaClient.get_relationships">get_relationships</a></code></li>
@@ -4197,6 +5840,7 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_testruns" href="#py_jama_rest_client.client.JamaClient.get_testruns">get_testruns</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_user" href="#py_jama_rest_client.client.JamaClient.get_user">get_user</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.get_users" href="#py_jama_rest_client.client.JamaClient.get_users">get_users</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.get_versioned_item" href="#py_jama_rest_client.client.JamaClient.get_versioned_item">get_versioned_item</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.patch_item" href="#py_jama_rest_client.client.JamaClient.patch_item">patch_item</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.post_item" href="#py_jama_rest_client.client.JamaClient.post_item">post_item</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.post_item_attachment" href="#py_jama_rest_client.client.JamaClient.post_item_attachment">post_item_attachment</a></code></li>
@@ -4213,6 +5857,7 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 <li><code><a title="py_jama_rest_client.client.JamaClient.put_test_run" href="#py_jama_rest_client.client.JamaClient.put_test_run">put_test_run</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.put_user" href="#py_jama_rest_client.client.JamaClient.put_user">put_user</a></code></li>
 <li><code><a title="py_jama_rest_client.client.JamaClient.put_user_active" href="#py_jama_rest_client.client.JamaClient.put_user_active">put_user_active</a></code></li>
+<li><code><a title="py_jama_rest_client.client.JamaClient.set_allowed_results_per_page" href="#py_jama_rest_client.client.JamaClient.set_allowed_results_per_page">set_allowed_results_per_page</a></code></li>
 </ul>
 </li>
 <li>
@@ -4230,9 +5875,7 @@ with a key of 'item' or 'project' and an value with the ID of the parent
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.5.3</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/py_jama_rest_client/core.html
+++ b/docs/py_jama_rest_client/core.html
@@ -3,25 +3,29 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.5.3" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>py_jama_rest_client.core API documentation</title>
 <meta name="description" content="" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.name small{font-weight:normal}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase;cursor:pointer}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
 <article id="content">
 <header>
-<h1 class="title"><code>py_jama_rest_client.core</code> module</h1>
+<h1 class="title">Module <code>py_jama_rest_client.core</code></h1>
 </header>
 <section id="section-intro">
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">import math
 
 import requests
@@ -31,6 +35,20 @@ import logging
 __DEBUG__ = False
 
 py_jama_rest_client_logger = logging.getLogger(&#39;py_jama_rest_client-core&#39;)
+
+
+class CoreException(Exception):
+    &#34;&#34;&#34;This is the base class for all exceptions raised by the Core&#34;&#34;&#34;
+
+    def __init__(self, message, status_code=None, reason=None):
+        super(CoreException, self).__init__(message)
+        self.status_code = status_code
+        self.reason = reason
+
+
+class UnauthorizedTokenException(CoreException):
+    &#34;&#34;&#34;This exception is thrown whenever fetching the oauth token returns a 401 unauthorized response.&#34;&#34;&#34;
+    pass
 
 
 class Core:
@@ -134,8 +152,13 @@ class Core:
         # By getting the system time before we get the token we avoid a potential bug where the token may be expired.
         time_before_request = time.time()
 
-        # Post to the token server
-        response = requests.post(self.__token_host, auth=self.__credentials, data=data, verify=self.__verify)
+        # Post to the token server, check if authorized
+        try:
+            response = requests.post(self.__token_host, auth=self.__credentials, data=data, verify=self.__verify)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            message = &#34;Unable to fetch token: &#34;
+            raise UnauthorizedTokenException(message + str(err), response.status_code)
 
         # If success get relevant data
         if response.status_code in [200, 201]:
@@ -166,15 +189,18 @@ class Core:
 <dl>
 <dt id="py_jama_rest_client.core.Core"><code class="flex name class">
 <span>class <span class="ident">Core</span></span>
+<span>(</span><span>host_name, user_credentials, api_version='/rest/v1/', oauth=False, verify=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This Class will contain a collection of methods that interact directly with the Jama API and return A Requests
+<div class="desc"><p>This Class will contain a collection of methods that interact directly with the Jama API and return A Requests
 Response Object.
 This class will give the user more fine grained access to the JAMA API.
 For more information
-on the Requests library visit: <a href="http://docs.python-requests.org/en/master/">http://docs.python-requests.org/en/master/</a></p></section>
+on the Requests library visit: <a href="http://docs.python-requests.org/en/master/">http://docs.python-requests.org/en/master/</a></p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">class Core:
     &#34;&#34;&#34; This Class will contain a collection of methods that interact directly with the Jama API and return A Requests
     Response Object.  This class will give the user more fine grained access to the JAMA API.  For more information
@@ -276,8 +302,13 @@ on the Requests library visit: <a href="http://docs.python-requests.org/en/maste
         # By getting the system time before we get the token we avoid a potential bug where the token may be expired.
         time_before_request = time.time()
 
-        # Post to the token server
-        response = requests.post(self.__token_host, auth=self.__credentials, data=data, verify=self.__verify)
+        # Post to the token server, check if authorized
+        try:
+            response = requests.post(self.__token_host, auth=self.__credentials, data=data, verify=self.__verify)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            message = &#34;Unable to fetch token: &#34;
+            raise UnauthorizedTokenException(message + str(err), response.status_code)
 
         # If success get relevant data
         if response.status_code in [200, 201]:
@@ -298,37 +329,15 @@ on the Requests library visit: <a href="http://docs.python-requests.org/en/maste
 </details>
 <h3>Methods</h3>
 <dl>
-<dt id="py_jama_rest_client.core.Core.__init__"><code class="name flex">
-<span>def <span class="ident">__init__</span></span>(<span>self, host_name, user_credentials, api_version=&#39;/rest/v1/&#39;, oauth=False, verify=True)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Initialize self.
-See help(type(self)) for accurate signature.</p></section>
-<details class="source">
-<summary>Source code</summary>
-<pre><code class="python">def __init__(self, host_name, user_credentials, api_version=&#39;/rest/v1/&#39;, oauth=False, verify=True):
-    # Instance variables
-    self.__api_version = api_version
-    self.__host_name = host_name + self.__api_version
-    self.__credentials = user_credentials
-    self.__oauth = oauth
-    self.__verify = verify
-    self.__session = requests.Session()
-
-    # Setup OAuth if needed.
-    if self.__oauth:
-        self.__token_host = host_name + &#39;/rest/oauth/token&#39;
-        self.__token = None
-        self.__get_fresh_token()</code></pre>
-</details>
-</dd>
 <dt id="py_jama_rest_client.core.Core.delete"><code class="name flex">
 <span>def <span class="ident">delete</span></span>(<span>self, resource, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will perform a delete operation on the specified resource</p></section>
+<div class="desc"><p>This method will perform a delete operation on the specified resource</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def delete(self, resource, **kwargs):
     &#34;&#34;&#34; This method will perform a delete operation on the specified resource&#34;&#34;&#34;
     url = self.__host_name + resource
@@ -346,9 +355,11 @@ See help(type(self)) for accurate signature.</p></section>
 <span>def <span class="ident">get</span></span>(<span>self, resource, params=None, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will perform a get operation on the specified resource</p></section>
+<div class="desc"><p>This method will perform a get operation on the specified resource</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def get(self, resource, params=None, **kwargs):
     &#34;&#34;&#34; This method will perform a get operation on the specified resource&#34;&#34;&#34;
     url = self.__host_name + resource
@@ -366,9 +377,11 @@ See help(type(self)) for accurate signature.</p></section>
 <span>def <span class="ident">patch</span></span>(<span>self, resource, params=None, data=None, json=None, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will perform a patch operation to the specified resource</p></section>
+<div class="desc"><p>This method will perform a patch operation to the specified resource</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def patch(self, resource, params=None, data=None, json=None, **kwargs):
     &#34;&#34;&#34; This method will perform a patch operation to the specified resource&#34;&#34;&#34;
     url = self.__host_name + resource
@@ -386,9 +399,11 @@ See help(type(self)) for accurate signature.</p></section>
 <span>def <span class="ident">post</span></span>(<span>self, resource, params=None, data=None, json=None, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will perform a post operation to the specified resource.</p></section>
+<div class="desc"><p>This method will perform a post operation to the specified resource.</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def post(self, resource, params=None, data=None, json=None, **kwargs):
     &#34;&#34;&#34; This method will perform a post operation to the specified resource.&#34;&#34;&#34;
     url = self.__host_name + resource
@@ -406,9 +421,11 @@ See help(type(self)) for accurate signature.</p></section>
 <span>def <span class="ident">put</span></span>(<span>self, resource, params=None, data=None, json=None, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>This method will perform a put operation to the specified resource</p></section>
+<div class="desc"><p>This method will perform a put operation to the specified resource</p></div>
 <details class="source">
-<summary>Source code</summary>
+<summary>
+<span>Expand source code</span>
+</summary>
 <pre><code class="python">def put(self, resource, params=None, data=None, json=None, **kwargs):
     &#34;&#34;&#34; This method will perform a put operation to the specified resource&#34;&#34;&#34;
     url = self.__host_name + resource
@@ -423,6 +440,55 @@ See help(type(self)) for accurate signature.</p></section>
 </details>
 </dd>
 </dl>
+</dd>
+<dt id="py_jama_rest_client.core.CoreException"><code class="flex name class">
+<span>class <span class="ident">CoreException</span></span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This is the base class for all exceptions raised by the Core</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class CoreException(Exception):
+    &#34;&#34;&#34;This is the base class for all exceptions raised by the Core&#34;&#34;&#34;
+
+    def __init__(self, message, status_code=None, reason=None):
+        super(CoreException, self).__init__(message)
+        self.status_code = status_code
+        self.reason = reason</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="py_jama_rest_client.core.UnauthorizedTokenException" href="#py_jama_rest_client.core.UnauthorizedTokenException">UnauthorizedTokenException</a></li>
+</ul>
+</dd>
+<dt id="py_jama_rest_client.core.UnauthorizedTokenException"><code class="flex name class">
+<span>class <span class="ident">UnauthorizedTokenException</span></span>
+<span>(</span><span>message, status_code=None, reason=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>This exception is thrown whenever fetching the oauth token returns a 401 unauthorized response.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class UnauthorizedTokenException(CoreException):
+    &#34;&#34;&#34;This exception is thrown whenever fetching the oauth token returns a 401 unauthorized response.&#34;&#34;&#34;
+    pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="py_jama_rest_client.core.CoreException" href="#py_jama_rest_client.core.CoreException">CoreException</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
 </dd>
 </dl>
 </section>
@@ -442,8 +508,7 @@ See help(type(self)) for accurate signature.</p></section>
 <ul>
 <li>
 <h4><code><a title="py_jama_rest_client.core.Core" href="#py_jama_rest_client.core.Core">Core</a></code></h4>
-<ul class="two-column">
-<li><code><a title="py_jama_rest_client.core.Core.__init__" href="#py_jama_rest_client.core.Core.__init__">__init__</a></code></li>
+<ul class="">
 <li><code><a title="py_jama_rest_client.core.Core.delete" href="#py_jama_rest_client.core.Core.delete">delete</a></code></li>
 <li><code><a title="py_jama_rest_client.core.Core.get" href="#py_jama_rest_client.core.Core.get">get</a></code></li>
 <li><code><a title="py_jama_rest_client.core.Core.patch" href="#py_jama_rest_client.core.Core.patch">patch</a></code></li>
@@ -451,15 +516,19 @@ See help(type(self)) for accurate signature.</p></section>
 <li><code><a title="py_jama_rest_client.core.Core.put" href="#py_jama_rest_client.core.Core.put">put</a></code></li>
 </ul>
 </li>
+<li>
+<h4><code><a title="py_jama_rest_client.core.CoreException" href="#py_jama_rest_client.core.CoreException">CoreException</a></code></h4>
+</li>
+<li>
+<h4><code><a title="py_jama_rest_client.core.UnauthorizedTokenException" href="#py_jama_rest_client.core.UnauthorizedTokenException">UnauthorizedTokenException</a></code></h4>
+</li>
 </ul>
 </li>
 </ul>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.5.3</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/py_jama_rest_client/index.html
+++ b/docs/py_jama_rest_client/index.html
@@ -3,21 +3,23 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.5.3" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>py_jama_rest_client API documentation</title>
 <meta name="description" content="" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.name small{font-weight:normal}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase;cursor:pointer}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
 <article id="content">
 <header>
-<h1 class="title"><code>py_jama_rest_client</code> module</h1>
+<h1 class="title">Package <code>py_jama_rest_client</code></h1>
 </header>
 <section id="section-intro">
 </section>
@@ -26,11 +28,11 @@
 <dl>
 <dt><code class="name"><a title="py_jama_rest_client.client" href="client.html">py_jama_rest_client.client</a></code></dt>
 <dd>
-<section class="desc"></section>
+<div class="desc"></div>
 </dd>
 <dt><code class="name"><a title="py_jama_rest_client.core" href="core.html">py_jama_rest_client.core</a></code></dt>
 <dd>
-<section class="desc"></section>
+<div class="desc"></div>
 </dd>
 </dl>
 </section>
@@ -57,9 +59,7 @@
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.5.3</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/py_jama_rest_client/client.py
+++ b/py_jama_rest_client/client.py
@@ -863,6 +863,42 @@ class JamaClient:
         tag_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return tag_results
 
+    def get_item_links(self, item_id):
+        """
+        This method will return all links in the specified item.
+        Args:
+            item_id: the item ID
+
+        Returns: a Json object with the links present in the item specified
+
+        """
+        resource_path = 'items/' + str(item_id) + '/links'
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()['data']
+
+    def get_filter_results_count(self, filter_id):
+        """
+        This method will return count of items found through the specified filter.
+        Args:
+            filter_id: the filter ID
+
+        Returns: a count of the items matched with the filter
+
+        """
+        resource_path = 'filters/' + str(filter_id) + '/count'
+        try:
+            response = self.__core.get(resource_path)
+        except CoreException as err:
+            py_jama_rest_client_logger.error(err)
+            raise APIException(str(err))
+        JamaClient.__handle_response_status(response)
+        return response.json()['data']
+
     def get_users(self, allowed_results_per_page=__allowed_results_per_page):
         """
         Gets a list of all active users visible to the current user
@@ -1502,3 +1538,4 @@ class JamaClient:
 
     def get_allowed_results_per_page(self):
         return self.__allowed_results_per_page
+    


### PR DESCRIPTION
1. API: get_filter_results_count:
This API returns the count of items matching a given filter id.
2. API: get_item_links:
This API returns the hyperlinks associated with a given item id.