### PR TITLE
Add support for releases endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ compatibility)
 - `GET` all projects
 - `POST` new attachment item
 
+##### Releases
+- `GET` releases for a specific project
+
 ##### Tags
 - `GET` all tags for a specific project
 - `POST` a new tag to a specific project

--- a/py_jama_rest_client/client.py
+++ b/py_jama_rest_client/client.py
@@ -162,6 +162,21 @@ class JamaClient:
         filter_results = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
         return filter_results
 
+    def get_releases(self, project_id, allowed_results_per_page=__allowed_results_per_page):
+        """
+        This method will return all the releases in a specified project.
+        Args:
+            project_id: the project ID
+            allowed_results_per_page: number of results per page
+
+        Returns: a Json array of item objects
+
+        """
+        resource_path = 'releases'
+        params = {'project': project_id}
+        item_data = self.__get_all(resource_path, params=params, allowed_results_per_page=allowed_results_per_page)
+        return item_data
+
     def get_items(self, project_id, allowed_results_per_page=__allowed_results_per_page):
         """
         This method will return all items in the specified project.

--- a/test/test_jamaClient.py
+++ b/test/test_jamaClient.py
@@ -16,6 +16,10 @@ class TestJamaClient(TestCase):
         projects = self.jama_client.get_projects()
         self.assertIsNotNone(projects)
 
+    def test_get_releases(self):
+        projects = self.jama_client.get_releases(project_id=116)
+        self.assertIsNotNone(projects)
+
     def test_get_items(self):
         project_id = 116
         items = self.jama_client.get_items(project_id)


### PR DESCRIPTION
I ran into a situation where I needed to get all of the releases in a project so I could update test runs with the current software release being tested. Although releases are essentially a pick list, they are a separate field type and do not show up when you GET all of the pick lists in a project.

Changes:
ADD: Function that returns all releases for a project
ADD: endpoint explanation to readme
ADD: test for releases endpoint